### PR TITLE
feat(services): Detect and enable fsevent forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,16 @@ To avoid this default behavior, add the following property to `devlab.yml` at th
 forward: false
 ```
 
+## Filesystem Event forwarding
+
+If you're running the Docker daemon remotely or in a VM, especially if you're mounting volumes with NFS, chances are your file changes in volumes aren't picked up by file change monitors running in docker. DevLab fixes that by integrating with [FS-EventBridge](https://github.com/TechnologyAdvice/fs_eventbridge). If you have the fs_eventbridge binary running in your VM, just add the following environment variable:
+
+```
+FS_EVENTBRIDGE_PORT=65056
+```
+
+DevLab will detect if you're running a Docker VM by looking for the `DOCKER_HOST` environment variable you already have set, and connects if it finds the above env var as well. The entire project folder from which you run the `lab` command will have change notifications for non-hidden files forwarded through the bridge.
+
 ## License
 
 DevLab is licensed under the MIT license. Please see `LICENSE.txt` for full details.

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "dependencies": {
     "bluebird": "^2.10.1",
     "chalk": "^1.1.1",
+    "fs-eventbridge-js": "^0.2.0",
     "js-yaml": "^3.4.2",
     "lodash": "^3.10.1",
     "minimist": "^1.2.0",

--- a/test/src/index.spec.js
+++ b/test/src/index.spec.js
@@ -167,16 +167,6 @@ describe('core', () => {
           })
           .then(done).catch(done)
       })
-
-      it('throws an error if DOCKER_HOST env var is malformed', done => {
-        process.env.DOCKER_HOST = 'malformed'
-        parseStub.returns({ hostname: '' })
-        core.run()
-          .then(() => {
-            expect(errorStub.args[0][0]).to.equal('Error running {{run}}, exited with code {{Error: DOCKER_HOST is malformed. Cannot start forwarders.}}')
-          })
-          .then(done).catch(done)
-      })
     })
 
     describe('building arguments', () => {


### PR DESCRIPTION
This one's a bit longer than just the EventBridge integration because I pulled the docker ip parsing out of the port forwarding section to avoid duplicate code.