### PR TITLE
feat(utils): adds orphan identification and cleanup utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,26 @@ Services which need to persist between runs can be set by providing `persist: tr
 
 Persisted services will not stop after the primary container finishes its task and can be used by the same project, other projects, or independently.
 
+## Container Management
+
+Since container shutdown is a detached, unattended process it is _possible_ for services to fail to shutdown. On each run, before starting services or executing tasks, Devlab will run a check and attempt to identify any orphaned services.
+
+If orphaned services are identified a warning message will appear at the beginning of the process to indicate the orphaned service(s) and commands to remedy/exit these containers.
+
+Additionally, the following commands can be run to cleanup any running containers:
+
+**Stop and Remove Devlab Containers:**
+
+```
+devlab --cleanup
+```
+
+**Stop and Remove ALL Containers:**
+
+```
+devlab --cleanup-all
+```
+
 ## Environment Variables (`env <array>`)
 
 Setting `env` array items will expose environment variables in the primary instance or services. These entries can be raw strings or use `${VAR}` notation, where `VAR` is an environment variable on the host machine to use. Entries should use the format `<ENV_VAR>=<VALUE>`

--- a/src/args.js
+++ b/src/args.js
@@ -2,6 +2,7 @@
 const _ = require('redash')
 const min = require('minimist')
 const pkg = require('../package.json')
+const utils = require('./utils')
 
 /* istanbul ignore next */
 const processArgs = process.argv[0] === 'node' ? 1 : 2
@@ -18,11 +19,13 @@ const args = {
    * - @property {string} help - the help text to display to the user
    */
   available: {
-    h: { action: 'showHelp', help: 'Displays help and usage' },
-    v: { action: 'showVersion', help: 'Displays the current installed version' },
-    e: { prop: 'exec', help: 'Run a custom command instead of defined task' },
-    f: { prop: 'from', help: 'Run with specified docker image' },
-    c: { prop: 'configPath', help: 'Run with custom config file path' }
+    'h': { action: 'showHelp', help: 'Displays help and usage' },
+    'v': { action: 'showVersion', help: 'Displays the current installed version' },
+    'e': { prop: 'exec', help: 'Run a custom command instead of defined task' },
+    'f': { prop: 'from', help: 'Run with specified docker image' },
+    'c': { prop: 'configPath', help: 'Run with custom config file path' },
+    'cleanup': { action: 'cleanupDL', help: 'Stops and removes any non-persisted Devlab containers' },
+    'cleanup-all': { action: 'cleanupAll', help: 'Stops and removes ALL docker containers' }
   },
   /**
    * Displays the help and usage message
@@ -31,7 +34,7 @@ const args = {
     let help = ''
     help += `  ${pkg.name} v.${pkg.version}\n\n`
     help += `  Usage: [${_.keys(pkg.bin).join('|')}] task [options]\n\n`
-    help += _.pipe(_.toPairs, _.map(([k, v]) => `  -${k} ${v.help}`), _.join('\n'))(args.available)
+    help += _.pipe(_.toPairs, _.map(([k, v]) => `  -${k} -- ${v.help}`), _.join('\n'))(args.available)
     console.log(`${help}\n`)
     process.exit(0)
   },
@@ -40,6 +43,20 @@ const args = {
    */
   showVersion: () => {
     console.log(pkg.version)
+    process.exit(0)
+  },
+  /**
+   * Calls the cleanup process for Devlab containers and exits
+   */
+  cleanupDL: () => {
+    utils.cleanup()
+    process.exit(0)
+  },
+  /**
+   * Calls the cleanup process for ALL containers and exits
+   */
+  cleanupAll: () => {
+    utils.cleanup(true)
     process.exit(0)
   },
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const command = require('./command')
 const services = require('./services')
 const proc = require('./proc')
 const output = require('./output')
+const utils = require('./utils')
 
 global.instanceId = require('shortid').generate()
 
@@ -71,8 +72,10 @@ const instance = {
   start: () => Promise.resolve().then(() => {
     // Get config (or throw)
     const cfg = instance.getConfig()
-    // Start services, then run command
-    return instance.startServices(cfg).then(instance.runCommand)
+    // Check orphans, start services, then run command
+    return utils.checkOrphans()
+      .then(() => instance.startServices(cfg))
+      .then(instance.runCommand)
   })
   .catch((e) => {
     services.stop()

--- a/src/output.js
+++ b/src/output.js
@@ -20,6 +20,11 @@ const output = {
    */
   error: (m) => console.log(`${chalk.red(logSymbols.error)} ${m}`),
   /**
+   * Output warning message
+   * @param {string} m Output message
+   */
+  warn: (m) => console.log(`${chalk.yellow(logSymbols.warning)} ${m}`),
+  /**
    * Output line, break
    */
   line: () => console.log(chalk.gray('‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧'))

--- a/src/utils.js
+++ b/src/utils.js
@@ -56,9 +56,12 @@ const utils = {
    * @returns {object} promise
    */
   checkOrphans: () => proc.exec('docker ps').then((ps) => {
-    const orphans = utils.findOrphans(ps)
+    const orphans = utils.parseOrphans(ps)
     if (orphans.length) {
-      output.warn(`The following containers may not have shut down correctly: ${orphans.join(', ')}`)
+      output.line()
+      output.warn(`These containers may not have exited correctly: ${orphans.join(', ')}`)
+      output.warn('You can attempt to remove these by running `devlab --cleanup`')
+      output.line()
     }
     return true
   })

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,7 @@
+const _ = require('redash')
+const proc = require('./proc')
+const output = require('./output')
+
 const utils = {
   /**
    * Runs docker stop && docker rm on containers currently running
@@ -5,15 +9,57 @@ const utils = {
    * @returns {object} promise
    */
   cleanup: (all = false) => Promise.resolve().then(() => {
-    return true
+    const findCmd = all ? 'docker ps -q' : 'docker ps --filter="name=dl_" -q'
+    proc.exec(findCmd)
+      .then((ids) => {
+        return ids.length
+          ? proc.exec(_.pipe(
+              _.split(/(?:\r\n|\r|\n)/g),
+              _.map((id) => {
+                return `docker stop ${id} && docker rm ${id}`
+              }),
+              _.join(' && ')
+            )(ids))
+          : true
+      })
   }),
   /**
    * Identifies and reports any (possible) orphan containers, i.e. containers
    * which 1) have the dl_ prefix, 2) are NOT primary containers and 3) have
    * no primary container running - deteremined by InstanceId suffix
+   * @returns {array} Names of orphaned containers
+   */
+  parseOrphans: (ps) => _.pipe(
+    _.split(/\r?\n/),
+    _.drop(1),
+    _.map((row) => {
+      let data = _.split(/\s\s+/g, row)
+      return [ _.last(data), data[3] ]
+    }),
+    _.filter((data) => _.test(/dl_/, _.head(data))),
+    _.map(([name, created]) => ({ instance: name.replace(/dl_\w+_/, ''), name, created })),
+    _.partition(container => _.test(/dl_primary/, container.name)),
+    ([primaries, others]) => {
+      const primaryInstances = _.map(c => c.instance, primaries)
+      return _.reject(c => _.contains(c.instance, primaryInstances), others)
+    },
+    _.filter((orph) => {
+      const [num, meas] = _.split(/\s/g, orph.created)
+      if (meas === 'seconds') return false
+      if (_.test(/minute/, meas)) return +num >= 5
+      return true
+    }),
+    _.map(_.prop('name'))
+  )(ps),
+  /**
+   * Outputs warning if any orphaned containers are found
    * @returns {object} promise
    */
-  findOrphans: () => Promise.resolve().then(() => {
+  checkOrphans: () => proc.exec('docker ps').then((ps) => {
+    const orphans = utils.findOrphans(ps)
+    if (orphans.length) {
+      output.warn(`The following containers may not have shut down correctly: ${orphans.join(', ')}`)
+    }
     return true
   })
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,21 @@
+const utils = {
+  /**
+   * Runs docker stop && docker rm on containers currently running
+   * @param {boolean} all If the run should include non-devlab containers
+   * @returns {object} promise
+   */
+  cleanup: (all = false) => Promise.resolve().then(() => {
+    return true
+  }),
+  /**
+   * Identifies and reports any (possible) orphan containers, i.e. containers
+   * which 1) have the dl_ prefix, 2) are NOT primary containers and 3) have
+   * no primary container running - deteremined by InstanceId suffix
+   * @returns {object} promise
+   */
+  findOrphans: () => Promise.resolve().then(() => {
+    return true
+  })
+}
+
+module.exports = utils

--- a/test/fixtures/docker-ps.js
+++ b/test/fixtures/docker-ps.js
@@ -1,0 +1,11 @@
+module.exports = {
+  full: `CONTAINER ID        IMAGE                 COMMAND                  CREATED             STATUS              PORTS               NAMES
+ce21175a53bd        mhart/alpine-node:6   "sh -c /bin/sh"          8 seconds ago       Up 7 seconds                            dl_primary_B1IvlwNEe
+308d0a174809        mongo:3.0             "/entrypoint.sh mongo"   8 seconds ago       Up 7 seconds        27017/tcp           dl_mongodb_B1IvlwNEe
+456sg6sg7sg7        mongo:3.0             "/entrypoint.sh mongo"   8 seconds ago       Up 7 seconds        27017/tcp           dl_orphan1_N67jski89
+2928yu387d77        mongo:3.0             "/entrypoint.sh mongo"   3 minutes ago       Up 7 seconds        27017/tcp           dl_orphan2_YUI9083uj
+839837sd9d98        mongo:3.0             "/entrypoint.sh mongo"   7 minutes ago       Up 7 seconds        27017/tcp           dl_orphan3_JKLod93dS
+90488yex73x8        mongo:3.0             "/entrypoint.sh mongo"   12 eons ago         Up 7 seconds        27017/tcp           dl_orphan4_MNJ9ie00d
+0207375303aa        redis:latest          "/entrypoint.sh redis"   5 hours ago         Up 5 hours          6379/tcp            redis`,
+  ids: `839837sd9d98\n90488yex73x8`
+}

--- a/test/fixtures/docker-ps.js
+++ b/test/fixtures/docker-ps.js
@@ -7,5 +7,5 @@ ce21175a53bd        mhart/alpine-node:6   "sh -c /bin/sh"          8 seconds ago
 839837sd9d98        mongo:3.0             "/entrypoint.sh mongo"   7 minutes ago       Up 7 seconds        27017/tcp           dl_orphan3_JKLod93dS
 90488yex73x8        mongo:3.0             "/entrypoint.sh mongo"   12 eons ago         Up 7 seconds        27017/tcp           dl_orphan4_MNJ9ie00d
 0207375303aa        redis:latest          "/entrypoint.sh redis"   5 hours ago         Up 5 hours          6379/tcp            redis`,
-  ids: `839837sd9d98\n90488yex73x8`
+  ids: `839837sd9d98\n90488yex73x8\n`
 }

--- a/test/src/args.spec.js
+++ b/test/src/args.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 const pkg = require('package.json')
 const args = require('src/args')
+const utils = require('src/utils')
 
 const fixtures = {
   args: { e: true, _: [ '/bin/bash' ] }
@@ -29,6 +30,28 @@ describe('args', () => {
       args.showVersion()
       expect(logSpy).to.be.calledWith(pkg.version)
       expect(processExitStub).to.be.calledWith(0)
+    })
+  })
+  describe('cleanupDL', () => {
+    let utilsCleanupStub
+    beforeEach(() => {
+      utilsCleanupStub = sinon.stub(utils, 'cleanup')
+    })
+    afterEach(() => utilsCleanupStub.restore())
+    it('call utils.cleanup with no arguments', () => {
+      args.cleanupDL()
+      expect(utilsCleanupStub).to.be.calledOnce()
+    })
+  })
+  describe('cleanupAll', () => {
+    let utilsCleanupStub
+    beforeEach(() => {
+      utilsCleanupStub = sinon.stub(utils, 'cleanup')
+    })
+    afterEach(() => utilsCleanupStub.restore())
+    it('call utils.cleanup with no arguments', () => {
+      args.cleanupAll()
+      expect(utilsCleanupStub).to.be.calledWith(true)
     })
   })
   describe('isArg', () => {

--- a/test/src/output.spec.js
+++ b/test/src/output.spec.js
@@ -26,6 +26,12 @@ describe('output', () => {
       expect(logSpy).to.be.called()
     })
   })
+  describe('warn', () => {
+    it('outputs a warning message', () => {
+      output.warn('test-warn')
+      expect(logSpy).to.be.called()
+    })
+  })
   describe('line', () => {
     it('outputs a break line', () => {
       output.line()

--- a/test/src/utils.spec.js
+++ b/test/src/utils.spec.js
@@ -1,4 +1,7 @@
 const utils = require('src/utils')
+const fixture = require('test/fixtures/docker-ps')
+const proc = require('src/proc')
+const output = require('src/output')
 
 describe('utils', () => {
   describe('cleanup', () => {
@@ -6,9 +9,31 @@ describe('utils', () => {
       return expect(utils.cleanup()).to.be.fulfilled()
     })
   })
-  describe('findOrphans', () => {
-    it('resolves', () => {
-      return expect(utils.findOrphans()).to.be.fulfilled()
+  describe('parseOrphans', () => {
+    it('returns array of orphaned containers', () => {
+      expect(utils.parseOrphans(fixture.full)).to.deep.equal([ 'dl_orphan3_JKLod93dS', 'dl_orphan4_MNJ9ie00d' ])
+    })
+  })
+  describe('checkOrphans', () => {
+    let outputWarnStub
+    beforeEach(() => {
+      outputWarnStub = sinon.stub(output, 'warn')
+    })
+    afterEach(() => {
+      if (proc.exec.restore) proc.exec.restore()
+      output.warn.restore()
+    })
+    it('resolves without warning if no orphans are identified', () => {
+      sinon.stub(proc, 'exec', () => Promise.resolve(''))
+      return utils.checkOrphans().then(() => {
+        expect(outputWarnStub).to.not.be.called()
+      })
+    })
+    it('resolves after warning of identified orphans', () => {
+      sinon.stub(proc, 'exec', () => Promise.resolve(fixture.full))
+      return utils.checkOrphans().then(() => {
+        expect(outputWarnStub).to.be.calledWith('The following containers may not have shut down correctly: dl_orphan3_JKLod93dS, dl_orphan4_MNJ9ie00d')
+      })
     })
   })
 })

--- a/test/src/utils.spec.js
+++ b/test/src/utils.spec.js
@@ -32,7 +32,7 @@ describe('utils', () => {
     it('resolves after warning of identified orphans', () => {
       sinon.stub(proc, 'exec', () => Promise.resolve(fixture.full))
       return utils.checkOrphans().then(() => {
-        expect(outputWarnStub).to.be.calledWith('The following containers may not have shut down correctly: dl_orphan3_JKLod93dS, dl_orphan4_MNJ9ie00d')
+        expect(outputWarnStub).to.be.calledWith('Theses containers may not have exited correctly: dl_orphan3_JKLod93dS, dl_orphan4_MNJ9ie00d')
       })
     })
   })

--- a/test/src/utils.spec.js
+++ b/test/src/utils.spec.js
@@ -1,0 +1,14 @@
+const utils = require('src/utils')
+
+describe('utils', () => {
+  describe('cleanup', () => {
+    it('resolves', () => {
+      return expect(utils.cleanup()).to.be.fulfilled()
+    })
+  })
+  describe('findOrphans', () => {
+    it('resolves', () => {
+      return expect(utils.findOrphans()).to.be.fulfilled()
+    })
+  })
+})


### PR DESCRIPTION
This PR includes the following:

* Closes #35; will warn if (potentially) orphaned services/containers are found at runtime
* Adds `devlab --cleanup` to `stop` and `rm` any Devlab services
* Adds `devlab --cleanup-all` to `stop` and `rm` ALL containers