### PR TITLE
fix(utils): fix cli name typo `devlab` -> `lab`

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -76,7 +76,7 @@ const utils = {
     if (orphans.length) {
       output.line()
       output.warn(`These containers may not have exited correctly: ${orphans.join(', ')}`)
-      output.warn('You can attempt to remove these by running `devlab --cleanup`')
+      output.warn('You can attempt to remove these by running `lab --cleanup`')
       output.line()
     }
     return true


### PR DESCRIPTION
See title.