### PR TITLE
Fix/script exec

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "test": "npm run lint -s && npm run test:cover -s",
     "test:cover": "istanbul cover _mocha test/src/**/*.spec.js",
-    "test:watch": "nodemon --exec \"npm run test:cover || exit 1\"",
+    "test:watch": "nodemon --exec \"mocha test/src/**/*.spec.js || exit 1\"",
     "e2e": "node test/system/run.js",
     "lint": "standard --fix --verbose"
   },

--- a/test/fixtures/instance.js
+++ b/test/fixtures/instance.js
@@ -16,26 +16,30 @@ const instance = {
         ]
       }
     ],
-    primary: [
-      'run',
-      '--rm',
-      '-it',
-      '-v',
-      '/tmp:/tmp',
-      '-w',
-      '/tmp',
-      '--privileged',
-      '-p',
-      '8080:8080',
-      '--link',
-      'dl_mongodb_test:mongodb',
-      '--name',
-      'dl_primary_test',
-      'node:6',
-      'sh',
-      '-c',
-      'echo "foo"'
-    ]
+    primary: {
+      args: [
+        'run',
+        '--rm',
+        '-it',
+        '-v',
+        '/tmp:/tmp',
+        '-v',
+        '/tmp/devlab.sh:/devlabExec',
+        '-w',
+        '/tmp',
+        '--privileged',
+        '-p',
+        '8080:8080',
+        '--link',
+        'dl_mongodb_test:mongodb',
+        '--name',
+        'dl_primary_test',
+        'node:6',
+        'sh',
+        '/devlabExec'
+      ],
+      cmd: '#!/bin/sh\nset -e;\necho "foo"'
+    }
   },
   task: {
     services: [
@@ -54,26 +58,30 @@ const instance = {
         ]
       }
     ],
-    primary: [
-      'run',
-      '--rm',
-      '-it',
-      '-v',
-      '/tmp:/tmp',
-      '-w',
-      '/tmp',
-      '--privileged',
-      '-p',
-      '8080:8080',
-      '--link',
-      'dl_mongodb_test:mongodb',
-      '--name',
-      'dl_primary_test',
-      'node:6',
-      'sh',
-      '-c',
-      'env | sort'
-    ]
+    primary: {
+      args: [
+        'run',
+        '--rm',
+        '-it',
+        '-v',
+        '/tmp:/tmp',
+        '-v',
+        '/tmp/devlab.sh:/devlabExec',
+        '-w',
+        '/tmp',
+        '--privileged',
+        '-p',
+        '8080:8080',
+        '--link',
+        'dl_mongodb_test:mongodb',
+        '--name',
+        'dl_primary_test',
+        'node:6',
+        'sh',
+        '/devlabExec'
+      ],
+      cmd: '#!/bin/sh\nset -e;\nenv | sort'
+    }
   }
 }
 

--- a/test/system/run.js
+++ b/test/system/run.js
@@ -40,7 +40,7 @@ const runner = (() => {
     console.log('Invalid tests.json file')
     process.exit(1)
   }
-  let testFails = 0
+  let testFails = []
   Promise.mapSeries(_.keys(tests), (name) => {
     const testObj = tests[name]
     console.log('\n\n#----------------------------------------------')
@@ -48,12 +48,15 @@ const runner = (() => {
     console.log(`# devlab ${testObj.args.join(' ')}`)
     console.log('#----------------------------------------------\n\n')
     return spawn(testObj.args).catch((c) => {
-      if (testObj.should === 'pass') testFails++
+      if (testObj.should === 'pass') testFails.push(name)
     })
   }).then(() => {
     // Results
     console.log('\n\n#----------------------------------------------')
-    console.log(`# TEST RESULTS: ${testFails} failures`)
+    console.log(`# TEST RESULTS: ${testFails.length} failures`)
+    if (testFails.length > 0) {
+      console.log('#', testFails.join(', '))
+    }
     console.log('#----------------------------------------------\n\n')
     // Exit code
     if (testFails > 0) {


### PR DESCRIPTION
Closes #47 

Implements new approach, instead of inlining the command(s) to run, it now builds a `/tmp/devlab.sh` file which is mounted in the container as `/devlabExec` and called during execution. This replaces the approach of just "joining" all commands with `&&` which would cause issues and had to be sanitized each run.