### PR TITLE
fix(exec-script-tmp): uses tmp and mounts volume instead of creating locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm install devlab -g
 
 *Obvious Note: You need to have [Docker](https://www.docker.com/) installed as well.*
 
-**Important Note**: In order to run the tasks, Devlab creates a temp file (`devlab.sh`). The tool will do it's best to determine the best location (usually `/tmp`), but this can be explicitly set by specifying the environment variable `DEVLAB_TMP`.
+**Important Note**: In order to run the tasks, Devlab creates a temp file (`devlab.sh`). The tool will do its best to determine the best location (usually `/tmp`), but this can be explicitly set by specifying the environment variable `DEVLAB_TMP`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ npm install devlab -g
 
 *Obvious Note: You need to have [Docker](https://www.docker.com/) installed as well.*
 
+**Important Note**: In order to run the tasks, Devlab creates a temp file (`devlab.sh`). The tool will do it's best to determine the best location (usually `/tmp`), but this can be explicitly set by specifying the environment variable `DEVLAB_TMP`.
+
 ## Usage
 
 Devlab is controlled by a `devlab.yml` file in the root of your project. A basic example is shown below:

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "mocha": "^2.3.3",
     "mocha-sinon": "^1.1.4",
     "nodemon": "^1.11.0",
+    "proxyquire": "^1.7.11",
     "sinon": "^1.17.0",
     "sinon-chai": "^2.8.0",
     "standard": "^8.5.0"
@@ -79,7 +80,8 @@
       "it",
       "expect",
       "sinon",
-      "cwd"
+      "cwd",
+      "proxyquire"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "log-symbols": "^1.0.2",
     "minimist": "^1.2.0",
     "ora": "^0.3.0",
+    "os-tmpdir": "^1.0.2",
     "shortid": "^2.2.6"
   },
   "standard": {

--- a/src/command.js
+++ b/src/command.js
@@ -96,19 +96,20 @@ const command = {
    * Returns full command arguments array
    * @param {object} cfg Config object for instance
    * @param {string} name Container name
+   * @param {string} tmpdir Path to temp execution file
    * @param {boolean} primary If this is primary, i.e. not a service container
    * @returns {object|array} Arguments for docker command
    */
-  get: (cfg, name, primary = false) => {
+  get: (cfg, name, tmpdir, primary = false) => {
     if (!cfg.from) throw new Error('Missing \'from\' property in config or argument')
     const cwd = process.cwd()
-    let args = primary ? [ 'run', '--rm', '-it', '-v', `${cwd}:${cwd}`, '-w', cwd, '--privileged' ] : [ 'run', '-d', '--privileged' ]
+    let args = primary ? [ 'run', '--rm', '-it', '-v', `${cwd}:${cwd}`, '-v', `${tmpdir}:${tmpdir}`, '-w', cwd, '--privileged' ] : [ 'run', '-d', '--privileged' ]
     args = args.concat(_.flatten([
       command.getArgs(cfg),
       command.getLinks(cfg),
       [ '--name', command.getName(name, cfg) ],
       cfg.from,
-      primary ? [ 'sh', 'devlab.sh' ] : []
+      primary ? [ 'sh', `${tmpdir}/devlab.sh` ] : []
     ]))
     return primary ? { args, cmd: command.getExec(cfg) } : args
   }

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@
 const _ = require('halcyon')
 const Promise = require('bluebird')
 const fs = require('fs')
+const tmpdir = process.env.TMPDIR || process.env.TMP || process.env.TEMP || '/tmp'
 const args = require('./args')
 const config = require('./config')
 const command = require('./command')
@@ -27,7 +28,7 @@ const instance = {
    */
   getConfig: () => {
     const cfg = services.filterEnabled(_.merge(config.load(args.parse().configPath), args.parse()))
-    return { services: services.get(cfg), primary: command.get(cfg, 'primary', true) }
+    return { services: services.get(cfg), primary: command.get(cfg, 'primary', tmpdir, true) }
   },
   /**
    * Starts services and resolves or rejects
@@ -79,11 +80,11 @@ const instance = {
     // Get config (or throw)
     const cfg = instance.getConfig()
     // Write the primary command to tmp script
-    return fs.writeFileAsync(`${process.cwd()}/devlab.sh`, cfg.primary.cmd)
+    console.log('writing', tmpdir)
+    return fs.writeFileAsync(`${tmpdir}/devlab.sh`, cfg.primary.cmd)
       .then(() => utils.checkOrphans())
       .then(() => instance.startServices(cfg))
       .then(instance.runCommand)
-      .then(() => fs.unlinkAsync(`${process.cwd()}/devlab.sh`))
   })
     .catch((e) => {
       services.stop()

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@
 const _ = require('halcyon')
 const Promise = require('bluebird')
 const fs = Promise.promisifyAll(require('fs'))
-const tmpdir = process.env.DEVLAB_TMP || require('os-tmpdir')()
 const args = require('./args')
 const config = require('./config')
 const command = require('./command')
@@ -11,6 +10,13 @@ const services = require('./services')
 const proc = require('./proc')
 const output = require('./output')
 const utils = require('./utils')
+
+/* istanbul ignore next: very os-specific crap */
+const tmpdir = process.env.DEVLAB_TMP
+      // If override set, use that
+      ? process.env.DEVLAB_TMP
+      // If MacOS TEMPDIR, use /tmp, else try to find using os-tmpdir
+      : process.env.TEMPDIR ? '/tmp' : require('os-tmpdir')()
 
 global.instanceId = require('shortid').generate()
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,12 +11,7 @@ const proc = require('./proc')
 const output = require('./output')
 const utils = require('./utils')
 
-/* istanbul ignore next: very os-specific crap */
-const tmpdir = process.env.DEVLAB_TMP
-      // If override set, use that
-      ? process.env.DEVLAB_TMP
-      // If MacOS TEMPDIR, use /tmp, else try to find using os-tmpdir
-      : process.env.TEMPDIR ? '/tmp' : require('os-tmpdir')()
+const tmpdir = require('./tempdir')()
 
 global.instanceId = require('shortid').generate()
 

--- a/src/index.js
+++ b/src/index.js
@@ -88,6 +88,7 @@ const instance = {
       .then(() => utils.checkOrphans())
       .then(() => instance.startServices(cfg))
       .then(instance.runCommand)
+      .then(services.stop)
   }).catch((e) => {
     services.stop()
     output.error(e.message || 'Process failed')

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@
 const _ = require('halcyon')
 const Promise = require('bluebird')
 const fs = Promise.promisifyAll(require('fs'))
-const tmpdir = process.env.TMPDIR || process.env.TMP || process.env.TEMP || '/tmp'
+const tmpdir = require('os-tmpdir')()
 const args = require('./args')
 const config = require('./config')
 const command = require('./command')

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@
 const _ = require('halcyon')
 const Promise = require('bluebird')
 const fs = Promise.promisifyAll(require('fs'))
-const tmpdir = require('os-tmpdir')()
+const tmpdir = process.env.DEVLAB_TMP || require('os-tmpdir')()
 const args = require('./args')
 const config = require('./config')
 const command = require('./command')

--- a/src/services.js
+++ b/src/services.js
@@ -48,7 +48,7 @@ const services = {
     ([name, value]) => ({
       name,
       persist: value.persist || false,
-      args: command.get(value, name)
+      args: command.get(value, name, null)
     })]), cfg.services),
   /**
    * Runs services and resolves or rejects

--- a/src/tempdir.js
+++ b/src/tempdir.js
@@ -1,0 +1,38 @@
+const output = require('./output')
+const fs = require('fs')
+
+/**
+ * Method to determine where to save devlab.sh tmp file
+ * @returns {String} path of writeable temp dir
+ */
+module.exports = () => {
+  /**
+   * Runs sync access for W_OK to determine if we can write to the path
+   * @params {String} path The path to test
+   * @returns {Boolean}
+   */
+  const isWriteable = (path) => {
+    try {
+      fs.accessSync(path, fs.W_OK)
+      return true
+    } catch (e) {
+      return false
+    }
+  }
+
+  // Check our options...
+  if (process.env.DEVLAB_TMP && isWriteable(process.env.DEVLAB_TMP)) {
+    // Use user-specified DEVLAB_TMP
+    return process.env.DEVLAB_TMP
+  } else if (isWriteable('/tmp')) {
+    // Use (most common) /tmp
+    return '/tmp'
+  } else if (isWriteable(require('os-tmpdir')())) {
+    // Use os-tmpdir's determination
+    return require('os-tmpdir')()
+  } else {
+    // No go, inform user they need to specify manually
+    output.error('Could not locate temp dir for writing, please specify DEVLAB_TMP environment variable')
+    process.exit(1)
+  }
+}

--- a/src/tempdir.js
+++ b/src/tempdir.js
@@ -1,4 +1,5 @@
 const output = require('./output')
+const ostmpdir = require('os-tmpdir')
 const fs = require('fs')
 
 /**
@@ -29,7 +30,7 @@ module.exports = () => {
     return '/tmp'
   } else if (isWriteable(require('os-tmpdir')())) {
     // Use os-tmpdir's determination
-    return require('os-tmpdir')()
+    return ostmpdir()
   } else {
     // No go, inform user they need to specify manually
     output.error('Could not locate temp dir for writing, please specify DEVLAB_TMP environment variable')

--- a/test/fixtures/instance.js
+++ b/test/fixtures/instance.js
@@ -23,6 +23,8 @@ const instance = {
         '-it',
         '-v',
         '/tmp:/tmp',
+        '-v',
+        '/tmp:/tmp',
         '-w',
         '/tmp',
         '--privileged',
@@ -34,7 +36,7 @@ const instance = {
         'dl_primary_test',
         'node:6',
         'sh',
-        'devlab.sh'
+        '/tmp/devlab.sh'
       ],
       cmd: '#!/bin/sh\nset -e;\necho "foo"'
     }
@@ -63,6 +65,8 @@ const instance = {
         '-it',
         '-v',
         '/tmp:/tmp',
+        '-v',
+        '/tmp:/tmp',
         '-w',
         '/tmp',
         '--privileged',
@@ -74,7 +78,7 @@ const instance = {
         'dl_primary_test',
         'node:6',
         'sh',
-        'devlab.sh'
+        '/tmp/devlab.sh'
       ],
       cmd: '#!/bin/sh\nset -e;\nenv | sort'
     }

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,5 +1,6 @@
 const chai = require('chai')
 const sinon = require('sinon')
+const proxyquire = require('proxyquire')
 const pchai = require('chai-as-promised')
 const dchai = require('dirty-chai')
 const schai = require('sinon-chai')
@@ -7,8 +8,9 @@ const mod = require('module')
 const path = require('path')
 global.sinon = sinon
 global.expect = chai.expect
-chai.use(pchai)
+global.proxyquire = proxyquire
 chai.use(dchai)
+chai.use(pchai)
 chai.use(schai)
 
 global.cwd = process.cwd()

--- a/test/src/command.spec.js
+++ b/test/src/command.spec.js
@@ -91,9 +91,9 @@ describe('command', () => {
     })
     it('returns object with array of arguments and command for a primary container config', () => {
       process.env.DL_TEST_EV = 'foo'
-      const actual = command.get({ from: 'mongo', env: [ 'DL_TEST_EV=${DL_TEST_EV}' ], expose: [ '8080:8080' ], run: [ 'foo' ], tasks: { foo: 'echo "foo"' } }, 'primary', true) // eslint-disable-line no-template-curly-in-string
+      const actual = command.get({ from: 'mongo', env: [ 'DL_TEST_EV=${DL_TEST_EV}' ], expose: [ '8080:8080' ], run: [ 'foo' ], tasks: { foo: 'echo "foo"' } }, 'primary', '/tmp', true) // eslint-disable-line no-template-curly-in-string
       expect(actual).to.deep.equal({
-        args: [ 'run', '--rm', '-it', '-v', '/tmp:/tmp', '-w', '/tmp', '--privileged', '-e', 'DL_TEST_EV=foo', '-p', '8080:8080', '--name', 'dl_primary_test', 'mongo', 'sh', 'devlab.sh' ],
+        args: [ 'run', '--rm', '-it', '-v', '/tmp:/tmp', '-v', '/tmp:/tmp', '-w', '/tmp', '--privileged', '-e', 'DL_TEST_EV=foo', '-p', '8080:8080', '--name', 'dl_primary_test', 'mongo', 'sh', '/tmp/devlab.sh' ],
         cmd: '#!/bin/sh\nset -e;\necho "foo"'
       })
       delete process.env.DL_TEST_EV

--- a/test/src/tempdir.spec.js
+++ b/test/src/tempdir.spec.js
@@ -1,0 +1,50 @@
+'use strict'
+const tempdir = proxyquire('src/tempdir', {
+  'os-tmpdir': () => '/ostmpdir'
+})
+const fs = require('fs')
+const output = require('src/output')
+
+describe('tempdir', () => {
+  let outputErrorStub
+  let processExitStub
+  before(() => {
+    outputErrorStub = sinon.stub(output, 'error')
+    processExitStub = sinon.stub(process, 'exit')
+  })
+  after(() => {
+    output.error.restore()
+    process.exit.restore()
+  })
+  it('uses DEVLAB_TMP if set and writeable', () => {
+    process.env.DEVLAB_TMP = __dirname
+    expect(tempdir()).to.equal(__dirname)
+    delete process.env.DEVLAB_TMP
+  })
+  it('uses /tmp if DEVLAB_TMP is not available', () => {
+    process.env.DEVLAB_TMP = '/var'
+    expect(tempdir()).to.equal('/tmp')
+    delete process.env.DEVLAB_TMP
+  })
+  it('uses /tmp if DEVLAB_TMP not set', () => {
+    expect(tempdir()).to.equal('/tmp')
+  })
+  it('uses os-tmpdir if DEVLAB_TMP and /tmp not available', () => {
+    sinon.stub(fs, 'accessSync', (path) => {
+      if (path === '/tmp') {
+        throw new Error('no dice')
+      }
+    })
+    expect(tempdir()).to.equal('/ostmpdir')
+    fs.accessSync.restore()
+  })
+  it('outputs error and exist if all else fails', () => {
+    sinon.stub(fs, 'accessSync', (path) => {
+      throw new Error('no dice')
+    })
+    tempdir()
+    expect(outputErrorStub).to.be.calledWith('Could not locate temp dir for writing, please specify DEVLAB_TMP environment variable')
+    expect(processExitStub).to.be.calledWith(1)
+    fs.accessSync.restore()
+  })
+})


### PR DESCRIPTION
Instead of creating local `devlab.sh` this will create in the OS's temp dir, mount, and execute.

Why this wasn't done initially is on me; I just defaulted to `/tmp` but this caused issues on Mac and Circle. Now the temp directory is determined by the `/src/tempdir` module which will allow either a custom setting via the `DEVLAB_TMP` environment variable, or will try to determine the best temp directory to use.

Tested both on my linux server and on my local Mac.

Closes #49 by no longer storing this exec script local.