### PR TITLE
feat(config): better config error messages

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -2,6 +2,7 @@
 
 const yaml = require('js-yaml')
 const fs = require('fs')
+const path = require('path')
 
 const config = {
   /**
@@ -10,14 +11,26 @@ const config = {
   defaultPath: `${process.cwd()}/devlab.yml`,
   /**
    * Loads config from yaml, attempts to parse to object
-   * @param {string} (path) Path to config file or use defaultPath
+   * @param {string} (configPath) Path to config file or use defaultPath
    * @returns {object}
    */
-  load: (path = config.defaultPath) => {
+  load: (configPath = config.defaultPath) => {
     try {
-      return yaml.safeLoad(fs.readFileSync(path, 'utf8'))
+      fs.statSync(configPath)
+    } catch (err) {
+      throw new Error([
+        `No config found at ${configPath}.`,
+        'Please create a ./devlab.yml file or specify one with the `-c` flag.'
+      ].join(' '))
+    }
+
+    try {
+      return yaml.safeLoad(fs.readFileSync(configPath, 'utf8'))
     } catch (e) {
-      throw new Error('Cannot load config file. Please ensure you have a valid ./devlab.yml file or specify one with the `-c` flag')
+      const relPath = path.relative(process.cwd(), configPath)
+      const error = new Error(`Please fix the errors in ${relPath}`)
+      error.message = error.message + `:\n\n${e.message}`
+      throw error
     }
   }
 }

--- a/test/fixtures/devlab-syntax-error.yml
+++ b/test/fixtures/devlab-syntax-error.yml
@@ -1,0 +1,13 @@
+from: mhart/alpine-node:6
+services:
+  - mongodb:
+     from: mongo:3.0
+     expose:
+       - 27017:27017
+     persist: false
+expose:
+  - 8080:8080
+tasks:
+  env: env | sort
+  bad-indent: |
+  echo "ruh roh! YLM error!"

--- a/test/src/config.spec.js
+++ b/test/src/config.spec.js
@@ -5,16 +5,27 @@ const fs = Promise.promisifyAll(require('fs'))
 describe('config', () => {
   describe('load', () => {
     const confPath = `${process.cwd()}/devlab.yml`
-    before(() => fs.writeFileAsync(confPath, 'from: node:4'))
-    after(() => fs.unlinkAsync(confPath))
+    beforeEach(() => fs.writeFileAsync(confPath, 'from: node:4'))
+    afterEach(() => fs.unlinkAsync(confPath))
     it('loads the $CWD/devlab.yml default config location', () => {
       expect(config.load()).to.deep.equal({ from: 'node:4' })
     })
     it('loads the devlab.yml from a custom path when specified', () => {
       expect(config.load(confPath)).to.deep.equal({ from: 'node:4' })
     })
-    it('exits the process if file cannot be loaded', () => {
-      expect(() => config.load('/no/conf')).to.throw('Cannot load config file. Please ensure you have a valid ./devlab.yml file or specify one with the `-c` flag')
+    it('exits the process if file cannot be found', () => {
+      expect(() => config.load('/no/conf'))
+        .to.throw('Please create a ./devlab.yml file or specify one with the `-c` flag.')
+    })
+    it('exits the process if file cannot be parsed', () => {
+      const error = [
+        'Please fix the errors in test/fixtures/devlab-syntax-error.yml:',
+        '',
+        'can not read an implicit mapping pair; a colon is missed at line 13, column 29:',
+        '      echo "ruh roh! YLM error!"',
+        '                                ^'
+      ].join('\n')
+      expect(() => config.load('test/fixtures/devlab-syntax-error.yml')).to.throw(error)
     })
   })
 })


### PR DESCRIPTION
Currently, the same message is used when there is no devlab.yml as when there is an invalid one.  Also, YML errors are not shown making it tough to know what is wrong.

This PR specifies the exact issue with config, either missing or invalid.  An invalid config will now also show the location and nature of the syntax error.

# Before

**Missing**
```
› lab test
✖ Cannot load config file. Please ensure you have a valid ./devlab.yml file or specify one with the `-c` flag
```

**Invalid**
```
› lab test
✖ Cannot load config file. Please ensure you have a valid ./devlab.yml file or specify one with the `-c` flag
```

# After

**Missing**
```
› lab test
✖ Please create a ./devlab.yml file or specify one with the `-c` flag.
```

**Invalid**
```
› lab test
✖ Please fix the errors in devlab.yml:

can not read a block mapping entry; a multiline key may not be an implicit key at line 66, column 5:
        # TODO pip doesn't check the tar ...
        ^
```
