### PR TITLE
feat(service-start-errors): outputs names of failed services

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,10 +45,11 @@ const instance = {
         servicesStartSpinner.succeed()
         return cfg
       })
-      .catch(() => {
+      .catch((e) => {
         servicesStartSpinner.fail()
+        const failed = e.svcs
         /* istanbul ignore next */
-        throw new Error(`Failed to start service${cfg.services.length > 1 ? 's' : ''}`)
+        throw new Error(`Failed to start service${failed.length > 1 ? 's' : ''}: ${failed.join(', ')}`)
       })
   },
   /**


### PR DESCRIPTION
Closes #41 

Instead of dumping logs this stops the process with an indication of what services failed so they can be investigated by inspecting docker logs.