### PR TITLE
feat(utils): handle async actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![CircleCI branch](https://img.shields.io/circleci/project/TechnologyAdvice/DevLab/master.svg?maxAge=2592000)]()
 [![Code Climate](https://codeclimate.com/github/TechnologyAdvice/DevLab/badges/gpa.svg)](https://codeclimate.com/github/TechnologyAdvice/DevLab)
-[![Test Coverage](https://codeclimate.com/github/TechnologyAdvice/DevLab/badges/coverage.svg)](https://codeclimate.com/github/TechnologyAdvice/DevLab/coverage)
-
+[![codecov](https://codecov.io/gh/TechnologyAdvice/DevLab/branch/master/graph/badge.svg)](https://codecov.io/gh/TechnologyAdvice/DevLab)
 **Updgrading from 2.x to 3.x: Please see [Release Notes](https://github.com/TechnologyAdvice/DevLab/releases/tag/v3.0.0)**
 
 # DevLab

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![CircleCI branch](https://img.shields.io/circleci/project/TechnologyAdvice/DevLab/master.svg?maxAge=2592000)]()
 [![Code Climate](https://codeclimate.com/github/TechnologyAdvice/DevLab/badges/gpa.svg)](https://codeclimate.com/github/TechnologyAdvice/DevLab)
 [![codecov](https://codecov.io/gh/TechnologyAdvice/DevLab/branch/master/graph/badge.svg)](https://codecov.io/gh/TechnologyAdvice/DevLab)
+
 **Updgrading from 2.x to 3.x: Please see [Release Notes](https://github.com/TechnologyAdvice/DevLab/releases/tag/v3.0.0)**
 
 # DevLab

--- a/circle.yml
+++ b/circle.yml
@@ -16,4 +16,4 @@ test:
     - npm install
     - npm test
   post:
-    - codeclimate-test-reporter < coverage/lcov.info
+    - bash <(curl -s https://codecov.io/bash)

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "preferGlobal": true,
   "scripts": {
     "test": "npm run lint -s && npm run test:cover -s",
-    "test:cover": "istanbul cover _mocha test/src/**/*.spec.js",
-    "test:watch": "nodemon --exec \"mocha test/src/**/*.spec.js || exit 1\"",
+    "test:cover": "istanbul cover --print none _mocha test/src/**/*.spec.js",
+    "test:watch": "nodemon --exec \"npm run test:cover || exit 1\"",
     "e2e": "node test/system/run.js",
     "lint": "standard --fix --verbose"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -26,8 +26,12 @@ const instance = {
    * @returns {object} Command instructions
    */
   getConfig: () => {
-    const cfg = services.filterEnabled(_.merge(config.load(args.parse().configPath), args.parse()))
-    return { services: services.get(cfg), primary: command.get(cfg, 'primary', tmpdir, true) }
+    return Promise.resolve()
+      .then(args.parse)
+      .then(parsedArgs => {
+        const cfg = services.filterEnabled(_.merge(config.load(parsedArgs.configPath), parsedArgs))
+        return { services: services.get(cfg), primary: command.get(cfg, 'primary', tmpdir, true) }
+      })
   },
   /**
    * Starts services and resolves or rejects
@@ -89,20 +93,21 @@ const instance = {
    * Initializes instance from config and args
    * @returns {object} promise
    */
-  start: () => Promise.resolve().then(() => {
-    // Get config (or throw)
-    const cfg = instance.getConfig()
-    // Write the primary command to tmp script
-    return fs.writeFileAsync(`${tmpdir}/devlab.sh`, cfg.primary.cmd)
-      .then(() => utils.checkOrphans())
-      .then(() => instance.startServices(cfg))
-      .then(instance.runCommand)
-      .then(instance.stopServices)
-  }).catch((e) => {
-    services.stop()
-    output.error(e.message || 'Process failed')
-    throw new Error('Process failed')
-  })
+  start: () => Promise.resolve()
+    .then(instance.getConfig)
+    .then(cfg => {
+      // Write the primary command to tmp script
+      return fs.writeFileAsync(`${tmpdir}/devlab.sh`, cfg.primary.cmd)
+        .then(() => utils.checkOrphans())
+        .then(() => instance.startServices(cfg))
+        .then(instance.runCommand)
+        .then(instance.stopServices)
+    })
+    .catch((e) => {
+      services.stop()
+      output.error(e.message || 'Process failed')
+      throw new Error('Process failed')
+    })
 }
 
 module.exports = instance

--- a/test/fixtures/docker-ps.js
+++ b/test/fixtures/docker-ps.js
@@ -7,5 +7,6 @@ ce21175a53bd        mhart/alpine-node:6   "sh -c /bin/sh"          8 seconds ago
 839837sd9d98        mongo:3.0             "/entrypoint.sh mongo"   7 minutes ago       Up 7 seconds        27017/tcp           dl_orphan3_JKLod93dS
 90488yex73x8        mongo:3.0             "/entrypoint.sh mongo"   12 eons ago         Up 7 seconds        27017/tcp           dl_orphan4_MNJ9ie00d
 0207375303aa        redis:latest          "/entrypoint.sh redis"   5 hours ago         Up 5 hours          6379/tcp            redis`,
-  ids: `839837sd9d98\n90488yex73x8\n`
+  ids: `839837sd9d98\n90488yex73x8\n`,
+  allIds: `ce21175a53bd\n308d0a174809\n456sg6sg7sg7\n2928yu387d77\n839837sd9d98\n90488yex73x8\n0207375303aa\n`
 }

--- a/test/src/args.spec.js
+++ b/test/src/args.spec.js
@@ -64,18 +64,19 @@ describe('args', () => {
   describe('cleanupDL', () => {
     let utilsCleanupStub
     beforeEach(() => {
-      utilsCleanupStub = sinon.stub(utils, 'cleanup')
+      utilsCleanupStub = sinon.stub(utils, 'cleanup', () => Promise.resolve())
     })
     afterEach(() => utilsCleanupStub.restore())
     it('call utils.cleanup with no arguments', () => {
-      args.cleanupDL()
-      expect(utilsCleanupStub).to.be.calledOnce()
+      return args.cleanupDL().then(() => {
+        expect(utilsCleanupStub).to.be.calledOnce()
+      })
     })
   })
   describe('cleanupAll', () => {
     let utilsCleanupStub
     beforeEach(() => {
-      utilsCleanupStub = sinon.stub(utils, 'cleanup')
+      utilsCleanupStub = sinon.stub(utils, 'cleanup', () => Promise.resolve())
     })
     afterEach(() => utilsCleanupStub.restore())
     it('call utils.cleanup with no arguments', () => {
@@ -104,18 +105,20 @@ describe('args', () => {
   describe('parse', () => {
     it('parses args object and returns formatted config object', () => {
       args.raw = fixtures.args
-      const actual = args.parse()
-      expect(actual).to.deep.equal({
-        exec: true,
-        run: [ '/bin/bash' ]
+      return args.parse().then(actual => {
+        expect(actual).to.deep.equal({
+          exec: true,
+          run: ['/bin/bash']
+        })
       })
     })
     it('parses args and calls an action when passed', () => {
       args.raw = { v: true }
       const showVersionStub = sinon.stub(args, 'showVersion')
-      args.parse()
-      expect(showVersionStub).to.be.calledOnce()
-      showVersionStub.restore()
+      return args.parse().then(() => {
+        expect(showVersionStub).to.be.calledOnce()
+        showVersionStub.restore()
+      })
     })
   })
 })

--- a/test/src/args.spec.js
+++ b/test/src/args.spec.js
@@ -7,17 +7,15 @@ const utils = require('src/utils')
 const fixtures = {
   args: { e: true, _: [ '/bin/bash' ] }
 }
+const sandbox = sinon.sandbox.create()
 
 describe('args', () => {
-  let processExitStub
-  let logSpy
   beforeEach(() => {
-    logSpy = sinon.spy(console, 'log')
-    processExitStub = sinon.stub(process, 'exit')
+    sandbox.spy(console, 'log')
+    sandbox.stub(process, 'exit')
   })
   afterEach(() => {
-    process.exit.restore()
-    logSpy.restore()
+    sandbox.restore()
   })
   describe('tasks', () => {
     const confPath = `${process.cwd()}/devlab.yml`
@@ -44,49 +42,77 @@ describe('args', () => {
         '  lint     eslint .',
         '  ci       stuff test'
       ].join('\n'))
-      expect(processExitStub).to.be.calledWith(0)
+      expect(process.exit).to.be.calledWith(0)
     })
   })
   describe('showHelp', () => {
     it('shows the help message and exits', () => {
       args.showHelp()
-      expect(logSpy).to.be.calledOnce()
-      expect(processExitStub).to.be.calledWith(0)
+      expect(console.log).to.be.calledOnce()
+      expect(process.exit).to.be.calledWith(0)
     })
   })
   describe('showVersion', () => {
     it('shows the installed version and exits', () => {
       args.showVersion()
-      expect(logSpy).to.be.calledWith(pkg.version)
-      expect(processExitStub).to.be.calledWith(0)
+      expect(console.log).to.be.calledWith(pkg.version)
+      expect(process.exit).to.be.calledWith(0)
     })
   })
   describe('cleanupDL', () => {
-    let utilsCleanupStub
     beforeEach(() => {
-      utilsCleanupStub = sinon.stub(utils, 'cleanup', () => Promise.resolve())
+      sandbox.stub(utils, 'cleanup', () => Promise.resolve())
     })
-    afterEach(() => utilsCleanupStub.restore())
     it('call utils.cleanup with no arguments', () => {
       return args.cleanupDL().then(() => {
-        expect(utilsCleanupStub).to.be.calledOnce()
+        expect(utils.cleanup).to.be.calledOnce()
       })
+    })
+    it('exits code 0 on success', () => {
+      return args.cleanupDL()
+        .then(() => {
+          expect(process.exit).to.have.been.calledOnce()
+          expect(process.exit).to.have.been.calledWithExactly(0)
+        })
+    })
+    it('exits code 1 on fail', () => {
+      utils.cleanup.restore()
+      sandbox.stub(utils, 'cleanup', () => Promise.reject())
+      return args.cleanupDL()
+        .then(() => {
+          expect(process.exit).to.have.been.calledOnce()
+          expect(process.exit).to.have.been.calledWithExactly(1)
+        })
     })
   })
   describe('cleanupAll', () => {
-    let utilsCleanupStub
     beforeEach(() => {
-      utilsCleanupStub = sinon.stub(utils, 'cleanup', () => Promise.resolve())
+      sandbox.stub(utils, 'cleanup', () => Promise.resolve())
     })
-    afterEach(() => utilsCleanupStub.restore())
     it('call utils.cleanup with no arguments', () => {
       args.cleanupAll()
-      expect(utilsCleanupStub).to.be.calledWith(true)
+      expect(utils.cleanup).to.be.calledWith(true)
+    })
+    it('exits code 0 on success', () => {
+      return args.cleanupAll()
+        .then(() => {
+          expect(process.exit).to.have.been.calledOnce()
+          expect(process.exit).to.have.been.calledWithExactly(0)
+        })
+    })
+    it('exits code 1 on fail', () => {
+      utils.cleanup.restore()
+      sandbox.stub(utils, 'cleanup', () => Promise.reject())
+      return args.cleanupAll()
+        .then(() => {
+          expect(process.exit).to.have.been.calledOnce()
+          expect(process.exit).to.have.been.calledWithExactly(1)
+        })
     })
   })
   describe('isArg', () => {
     it('returns true if argument is valid', () => {
-      expect(args.isArg('f')).to.be.true
+      expect(args.isArg('f')).to.be.true()
     })
     it('displays an error and exits if argument is not valid', () => {
       expect(() => args.isArg('nope')).to.throw('Invalid argument \'nope\', please see documentation')
@@ -114,10 +140,9 @@ describe('args', () => {
     })
     it('parses args and calls an action when passed', () => {
       args.raw = { v: true }
-      const showVersionStub = sinon.stub(args, 'showVersion')
+      sandbox.stub(args, 'showVersion')
       return args.parse().then(() => {
-        expect(showVersionStub).to.be.calledOnce()
-        showVersionStub.restore()
+        expect(args.showVersion).to.be.calledOnce()
       })
     })
   })

--- a/test/src/index.spec.js
+++ b/test/src/index.spec.js
@@ -98,11 +98,15 @@ describe('index', () => {
   describe('getConfig', () => {
     it('loads config and args and returns exec run command objects', () => {
       args.raw = { f: 'node:6', e: 'echo "foo"', _: [], c: configPath }
-      expect(instance.getConfig()).to.deep.equal(fixtures.exec)
+      return instance.getConfig().then(cfg => {
+        expect(cfg).to.deep.equal(fixtures.exec)
+      })
     })
     it('loads config and args and returns task run command objects', () => {
       args.raw = { f: 'node:6', _: [ 'env' ], c: configPath }
-      expect(instance.getConfig()).to.deep.equal(fixtures.task)
+      return instance.getConfig().then(cfg => {
+        expect(cfg).to.deep.equal(fixtures.task)
+      })
     })
   })
   describe('start', () => {


### PR DESCRIPTION
As shown in #54, `--cleanup` with 20 stray containers took 1m 42s.  This is because they were shut down in series.

This PR adds async parallel support to actions, allowing us to kick off a process for every container simultaneously.  The result, shutting down any number of containers only takes as long as the longest container.  Woot!  🦉 

## Before: 1m 42, After: 12s

![http://g.recordit.co/pR04vTKDCo.gif](http://g.recordit.co/pR04vTKDCo.gif)