### PR TITLE
feat(stop-grace-period): handles stopTimeSecs prop on service containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,22 @@ Setting `volumes` will mount volumes on the host machine to designated paths on 
 
 Setting `hosts` will update the hosts configuration for the container. Entries should use the format `<HOST_NAME>:<ADDRESS>`
 
+## Service Stop Time (`stopTimeSecs <integer>`)
+
+The standard procedure for stopping a Docker container is via the `stop` command which sends `SIGTERM` and allows a grace period (default: `10s`) for the container to exit on its own.
+
+Some containers may not exit via `SIGTERM` (or may hang). In this case, the service container can utilize the `stopTimeSecs` property:
+
+```yaml
+services:
+  - mongo:
+      from: mongo:3.0
+      stopTimeSecs: 3
+```
+
+The `stopTimeSecs` above would forcibly stop the container after 3 seconds using [Docker's `stop` command's `-t` option](https://docs.docker.com/engine/reference/commandline/stop/).
+
+
 ## Development
 
 To run tests, fork & clone the repository then run `npm install && npm test`.

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Setting `hosts` will update the hosts configuration for the container. Entries s
 
 ## Service Stop Time (`stopTimeSecs <integer>`)
 
-The standard procedure for stopping a Docker container is via the `stop` command which sends `SIGTERM` and allows a grace period (default: `10s`) for the container to exit on its own.
+The standard procedure for stopping a Docker container is the `stop` command which sends `SIGTERM` and allows a grace period (default: `10`) for the container to exit on its own.
 
 Some containers may not exit via `SIGTERM` (or may hang). In this case, the service container can utilize the `stopTimeSecs` property:
 

--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,6 @@ const instance = {
       .then(() => {
         output.line()
         output.success(`Command exited after ${(Date.now() - instance.startTS) / 1000}s`)
-        services.stop()
         return true
       })
       .catch((code) => {

--- a/src/services.js
+++ b/src/services.js
@@ -49,7 +49,7 @@ const services = {
     ([name, value]) => ({
       name,
       persist: value.persist || false,
-      stopTimeSecs: value.stopTimeSecs || 10,
+      stopTimeSecs: _.isType('number', value.stopTimeSecs) ? value.stopTimeSecs : 10,
       args: command.get(value, name, null)
     })]), cfg.services),
   /**

--- a/src/services.js
+++ b/src/services.js
@@ -49,6 +49,7 @@ const services = {
     ([name, value]) => ({
       name,
       persist: value.persist || false,
+      stopTimeSecs: value.stopTimeSecs || 10,
       args: command.get(value, name, null)
     })]), cfg.services),
   /**
@@ -63,7 +64,7 @@ const services = {
       return proc.exec(`docker ps -f name=${curName} -q`).then((res) => {
         if (res && res.toString().length) return Promise.resolve() // Already running, resolve
         return proc.run(cur.args, true)
-          .then(() => services.running.push(curName))
+          .then(() => services.running.push({ name: curName, stopTimeSecs: cur.stopTimeSecs }))
           .catch(() => errors.push(cur.name))
       })
     }, svc))
@@ -83,8 +84,8 @@ const services = {
     const errors = []
     return Promise.all(
       _.pipe([
-        _.filter(_.test(/dl_/)),
-        _.map(svc => proc.run([ 'stop', svc ], true).catch(() => errors.push(svc)))
+        _.filter(svc => _.test(/dl_/, svc.name)),
+        _.map(svc => proc.run([ 'stop', '-t', svc.stopTimeSecs, svc.name ], true).catch(() => errors.push(svc.name)))
       ])(services.running))
       .then(() => {
         const stopError = new Error()

--- a/test/fixtures/instance.js
+++ b/test/fixtures/instance.js
@@ -4,6 +4,7 @@ const instance = {
       {
         name: 'mongodb',
         persist: false,
+        stopTimeSecs: 10,
         args: [
           'run',
           '-d',
@@ -47,6 +48,7 @@ const instance = {
       {
         name: 'mongodb',
         persist: false,
+        stopTimeSecs: 10,
         args: [
           'run',
           '-d',

--- a/test/fixtures/service.js
+++ b/test/fixtures/service.js
@@ -1,6 +1,7 @@
 module.exports = [
   {
     name: 'mongodb',
+    stopTimeSecs: 10,
     args: [
       'run',
       '-d',

--- a/test/project/devlab.yml
+++ b/test/project/devlab.yml
@@ -2,6 +2,7 @@ from: mhart/alpine-node:6
 services:
   - mongodb:
       from: mongo:latest
+      stopTimeSecs: 3
   - redis:
       from: redis:latest
       persist: true

--- a/test/src/services.spec.js
+++ b/test/src/services.spec.js
@@ -35,7 +35,7 @@ describe('services', () => {
       })
       procRunStub = sinon.stub(proc, 'run', () => Promise.resolve())
       return services.run(fixture).then(() => {
-        expect(services.running).to.deep.equal([ 'dl_mongodb_test' ])
+        expect(services.running).to.deep.equal([ { name: 'dl_mongodb_test', stopTimeSecs: 10 } ])
       })
     })
     it('rejects when a service fails to start', () => {
@@ -72,18 +72,18 @@ describe('services', () => {
         })
     })
     it('resolves after calling proc.run with stop command for running services', () => {
-      services.running = [ 'dl_foo_test', 'dl_bar_test' ]
+      services.running = [ { name: 'dl_foo_test', stopTimeSecs: 10 }, { name: 'dl_bar_test', stopTimeSecs: 10 } ]
       return services.stop()
         .then(() => {
-          expect(procRunStub.getCalls()[0].args[0]).to.deep.equal([ 'stop', 'dl_foo_test' ])
-          expect(procRunStub.getCalls()[1].args[0]).to.deep.equal([ 'stop', 'dl_bar_test' ])
+          expect(procRunStub.getCalls()[0].args[0]).to.deep.equal([ 'stop', '-t', 10, 'dl_foo_test' ])
+          expect(procRunStub.getCalls()[1].args[0]).to.deep.equal([ 'stop', '-t', 10, 'dl_bar_test' ])
         })
     })
     it('resolves after calling proc with stop and rm only for non-persistent services', () => {
-      services.running = [ 'dl_foo_test', 'bar' ]
+      services.running = [ { name: 'dl_foo_test', stopTimeSecs: 10 }, { name: 'bar' } ]
       return services.stop()
         .then(() => {
-          expect(procRunStub.getCalls()[0].args[0]).to.deep.equal([ 'stop', 'dl_foo_test' ])
+          expect(procRunStub.getCalls()[0].args[0]).to.deep.equal([ 'stop', '-t', 10, 'dl_foo_test' ])
         })
     })
     it('rejects with error containing names of services that failed', () => {


### PR DESCRIPTION
Allows users to specify `stopTimeSecs` property on service containers which will call `docker stop -t <n.Integer>' with custom timeout. Defaults to Docker default of `10s`.

Closes #58