### PR TITLE
feat(global-stop-time): adds ability to set stopTimeSecs globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,9 @@ services:
 
 The `stopTimeSecs` above would forcibly stop the container after 3 seconds using [Docker's `stop` command's `-t` option](https://docs.docker.com/engine/reference/commandline/stop/).
 
+**Global Setting:**
+
+In addition to setting the `stopTimeSecs` per service, this property can be set in the root of the `devlab.yml` configuration and will be applied to any services that don't have an explicit `stopTimeSecs` property.
 
 ## Development
 

--- a/src/services.js
+++ b/src/services.js
@@ -39,6 +39,17 @@ const services = {
     return cfg
   },
   /**
+   * Returns stopTimeSecs prop from either the (1) service config (2) global config or (3) default
+   * @param {object} cfg Instance config object
+   * @param {object} svc Service config object
+   * @returns {number}
+   */
+  getStopTimeSecs: (cfg, svc) => {
+    if (_.isType('number', svc.stopTimeSecs)) return svc.stopTimeSecs
+    if (_.isType('number', cfg.stopTimeSecs)) return cfg.stopTimeSecs
+    return 10
+  },
+  /**
    * Gets all services and returns name, persistence, and arguments
    * @param {Object} cfg Instance config object
    * @returns {array} Array of services names, persistence and run args
@@ -49,7 +60,7 @@ const services = {
     ([name, value]) => ({
       name,
       persist: value.persist || false,
-      stopTimeSecs: _.isType('number', value.stopTimeSecs) ? value.stopTimeSecs : 10,
+      stopTimeSecs: services.getStopTimeSecs(cfg, value),
       args: command.get(value, name, null)
     })]), cfg.services),
   /**

--- a/test/project/devlab.yml
+++ b/test/project/devlab.yml
@@ -2,7 +2,6 @@ from: mhart/alpine-node:6
 services:
   - mongodb:
       from: mongo:latest
-      stopTimeSecs: 3
   - redis:
       from: redis:latest
       persist: true

--- a/test/src/services.spec.js
+++ b/test/src/services.spec.js
@@ -8,6 +8,21 @@ describe('services', () => {
   afterEach(() => {
     services.running = []
   })
+  describe('getStopTimeSecs', () => {
+    it('uses the service config stopTimeSecs property if exists', () => {
+      const cfg = { stopTimeSecs: 3 }
+      const svc = { stopTimeSecs: 5 }
+      expect(services.getStopTimeSecs(cfg, svc)).to.equal(5)
+    })
+    it('uses the global config stopTimeSecs property if exists and no service config is set', () => {
+      const cfg = { stopTimeSecs: 3 }
+      const svc = {}
+      expect(services.getStopTimeSecs(cfg, svc)).to.equal(3)
+    })
+    it('uses the system default if neither global or service config props are set', () => {
+      expect(services.getStopTimeSecs({}, {})).to.equal(10)
+    })
+  })
   describe('get', () => {
     before(() => {
       config.defaultPath = path.resolve(__dirname, '../fixtures/devlab.yml')


### PR DESCRIPTION
Can now set `stopTimeSecs` per service or globally (in the root of `devlab.yml` config). The system will prioritize 1) service settings, 2) global settings then 3) default to `10`.