### PR TITLE
chore(lint): update lint and normalize style

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "chai": "^3.3.0",
     "chai-as-promised": "^6.0.0",
     "dirty-chai": "^1.2.2",
-    "eslint": "^2.10.2",
     "istanbul": "^0.4.3",
     "mocha": "^2.3.3",
     "mocha-sinon": "^1.1.4",
@@ -54,7 +53,7 @@
     "proxyquire": "^1.7.11",
     "sinon": "^1.17.0",
     "sinon-chai": "^2.8.0",
-    "standard": "^8.5.0"
+    "standard": "^8.6.0"
   },
   "dependencies": {
     "bluebird": "^3.4.6",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test:cover": "istanbul cover _mocha test/src/**/*.spec.js",
     "test:watch": "nodemon --exec \"npm run test:cover || exit 1\"",
     "e2e": "node test/system/run.js",
-    "lint": "standard --fix --verbose"
+    "lint": "standard --fix --verbose | snazzy"
   },
   "homepage": "https://github.com/TechnologyAdvice/DevLab",
   "repository": {
@@ -53,6 +53,7 @@
     "proxyquire": "^1.7.11",
     "sinon": "^1.17.0",
     "sinon-chai": "^2.8.0",
+    "snazzy": "^6.0.0",
     "standard": "^8.6.0"
   },
   "dependencies": {

--- a/src/command.js
+++ b/src/command.js
@@ -27,7 +27,7 @@ const command = {
    * @param {array} args Array of values
    * @returns {array}
    */
-  parseArgs: (type, args) => _.chain((item) => ([ command.args[type], command.parseHostEnvVars(item) ]), args),
+  parseArgs: (type, args) => _.chain((item) => ([command.args[type], command.parseHostEnvVars(item)]), args),
   /**
    * Parses config object and returns container name. Will have dl_ prefix and
    * InstanceID suffix if ephemeral, unaltered name for persisted containers
@@ -103,13 +103,13 @@ const command = {
   get: (cfg, name, tmpdir, primary = false) => {
     if (!cfg.from) throw new Error('Missing \'from\' property in config or argument')
     const cwd = process.cwd()
-    let args = primary ? [ 'run', '--rm', '-it', '-v', `${cwd}:${cwd}`, '-v', `${tmpdir}:${tmpdir}`, '-w', cwd, '--privileged' ] : [ 'run', '-d', '--rm', '--privileged' ]
+    let args = primary ? ['run', '--rm', '-it', '-v', `${cwd}:${cwd}`, '-v', `${tmpdir}:${tmpdir}`, '-w', cwd, '--privileged'] : ['run', '-d', '--rm', '--privileged']
     args = args.concat(_.flatten([
       command.getArgs(cfg),
       command.getLinks(cfg),
-      [ '--name', command.getName(name, cfg) ],
+      ['--name', command.getName(name, cfg)],
       cfg.from,
-      primary ? [ 'sh', `${tmpdir}/devlab.sh` ] : []
+      primary ? ['sh', `${tmpdir}/devlab.sh`] : []
     ]))
     return primary ? { args, cmd: command.getExec(cfg) } : args
   }

--- a/src/proc.js
+++ b/src/proc.js
@@ -12,7 +12,7 @@ const proc = {
    */
   run: (args, silent = false) => new Promise((resolve, reject) => {
     const opts = { env: process.env, cwd: process.env.HOME }
-    opts.stdio = silent ? [ null, null, null ] : [ 'inherit', process.stdout, process.stdout ]
+    opts.stdio = silent ? [null, null, null] : ['inherit', process.stdout, process.stdout]
     // Start
     const p = cp.spawn('docker', args, opts)
     // Handle close
@@ -25,7 +25,7 @@ const proc = {
    * @param {string} cmd Command to execute
    */
   runDetached: (cmd) => {
-    const p = cp.spawn('sh', [ '-c', cmd ], {
+    const p = cp.spawn('sh', ['-c', cmd], {
       detached: true,
       stdio: 'ignore'
     })

--- a/src/services.js
+++ b/src/services.js
@@ -85,7 +85,7 @@ const services = {
     return Promise.all(
       _.pipe([
         _.filter(svc => _.test(/dl_/, svc.name)),
-        _.map(svc => proc.run([ 'stop', '-t', svc.stopTimeSecs, svc.name ], true).catch(() => errors.push(svc.name)))
+        _.map(svc => proc.run(['stop', '-t', svc.stopTimeSecs, svc.name], true).catch(() => errors.push(svc.name)))
       ])(services.running))
       .then(() => {
         const stopError = new Error()

--- a/src/utils.js
+++ b/src/utils.js
@@ -58,7 +58,7 @@ const utils = {
     _.drop(1),
     _.map((row) => {
       let data = _.split(/\s\s+/g, row)
-      return [ _.last(data), data[3] ]
+      return [_.last(data), data[3]]
     }),
     _.filter((data) => _.test(/dl_/, _.head(data))),
     _.map(([name, created]) => ({ instance: name.replace(/dl_\w+_/, ''), name, created })),

--- a/test/project/.eslintrc
+++ b/test/project/.eslintrc
@@ -152,7 +152,7 @@
     "no-underscore-dangle": 0,       // http://eslint.org/docs/rules/no-underscore-dangle
     "one-var": [2, "never"],         // http://eslint.org/docs/rules/one-var
     "padded-blocks": [2, "never"],   // http://eslint.org/docs/rules/padded-blocks
-    "semi": [ 2, "never" ],          // http://eslint.org/docs/rules/semi
+    "semi": [2, "never"],            // http://eslint.org/docs/rules/semi
     "semi-spacing": [2, {            // http://eslint.org/docs/rules/semi-spacing
       "before": false,
       "after": true

--- a/test/src/args.spec.js
+++ b/test/src/args.spec.js
@@ -5,7 +5,7 @@ const args = require('src/args')
 const utils = require('src/utils')
 
 const fixtures = {
-  args: { e: true, _: [ '/bin/bash' ] }
+  args: { e: true, _: ['/bin/bash'] }
 }
 const sandbox = sinon.sandbox.create()
 
@@ -120,8 +120,8 @@ describe('args', () => {
   })
   describe('getTask', () => {
     it('returns string with task', () => {
-      args.raw = { _: [ 'foo', 'bar' ] }
-      expect(args.getTask()).to.deep.equal([ 'foo', 'bar' ])
+      args.raw = { _: ['foo', 'bar'] }
+      expect(args.getTask()).to.deep.equal(['foo', 'bar'])
     })
     it('returns empty string if no task specified', () => {
       args.raw = {}

--- a/test/src/command.spec.js
+++ b/test/src/command.spec.js
@@ -16,7 +16,7 @@ describe('command', () => {
   })
   describe('parseArgs', () => {
     it('returns an array of a specific argument type and its values', () => {
-      expect(command.parseArgs('expose', [ '8080:8080', '9090:9090' ])).to.deep.equal([ '-p', '8080:8080', '-p', '9090:9090' ])
+      expect(command.parseArgs('expose', ['8080:8080', '9090:9090'])).to.deep.equal(['-p', '8080:8080', '-p', '9090:9090'])
     })
   })
   describe('getName', () => {
@@ -30,7 +30,7 @@ describe('command', () => {
   })
   describe('getArgs', () => {
     it('returns array of all args to run with command based off config', () => {
-      expect(command.getArgs({ expose: [ '8080:8080' ], volumes: [ '/tmp:/tmp' ] })).to.deep.equal([ '-p', '8080:8080', '-v', '/tmp:/tmp' ])
+      expect(command.getArgs({ expose: ['8080:8080'], volumes: ['/tmp:/tmp'] })).to.deep.equal(['-p', '8080:8080', '-v', '/tmp:/tmp'])
     })
     it('outputs a warning if an argument is not an array', () => {
       expect(() => command.getArgs({ env: 'foo' })).to.throw('Config error: \'env\' should be an array')
@@ -47,17 +47,17 @@ describe('command', () => {
       expect(() => command.getExec({ tasks: { foo: 'echo \'bar\'' } })).to.throw('No task has been specified')
     })
     it('throws error if invalid task is specified', () => {
-      expect(() => command.getExec({ run: [ 'foo' ], tasks: { bar: 'echo "foo"' } })).to.throw('Task \'foo\' does not exist')
+      expect(() => command.getExec({ run: ['foo'], tasks: { bar: 'echo "foo"' } })).to.throw('Task \'foo\' does not exist')
     })
     it('throws error if no cmd is specified in task object definition', () => {
-      expect(() => command.getExec({ run: [ 'foo' ], tasks: { foo: { disable: 'testService' } } })).to.throw('Task \'foo\' has no command defined.')
+      expect(() => command.getExec({ run: ['foo'], tasks: { foo: { disable: 'testService' } } })).to.throw('Task \'foo\' has no command defined.')
     })
     it('returns exec task array when all criteria are met', () => {
-      const actual = command.getExec({ run: [ 'foo' ], before: 'bar', after: 'bizz', tasks: { foo: 'echo "foo"\necho "bar"' } })
+      const actual = command.getExec({ run: ['foo'], before: 'bar', after: 'bizz', tasks: { foo: 'echo "foo"\necho "bar"' } })
       expect(actual).to.equal('#!/bin/sh\nset -e;\nbar\necho "foo"\necho "bar"\nbizz')
     })
     it('returns exec task array when multiple tasks are called', () => {
-      const actual = command.getExec({ run: [ 'foo', 'fizz' ], before: 'bar', after: 'bizz', tasks: { foo: 'echo "foo"\necho "bar"', fizz: { cmd: 'buzz' } } })
+      const actual = command.getExec({ run: ['foo', 'fizz'], before: 'bar', after: 'bizz', tasks: { foo: 'echo "foo"\necho "bar"', fizz: { cmd: 'buzz' } } })
       expect(actual).to.equal('#!/bin/sh\nset -e;\nbar\necho "foo"\necho "bar"\nbuzz\nbizz')
     })
   })
@@ -66,10 +66,10 @@ describe('command', () => {
       expect(command.getLinks({})).to.deep.equal([])
     })
     it('returns formatted link arguments if services are present', () => {
-      expect(command.getLinks({ services: [ { foo: {} }, { bar: {} } ] })).to.deep.equal([ '--link', 'dl_foo_test:foo', '--link', 'dl_bar_test:bar' ])
+      expect(command.getLinks({ services: [{ foo: {} }, { bar: {} }] })).to.deep.equal(['--link', 'dl_foo_test:foo', '--link', 'dl_bar_test:bar'])
     })
     it('returns formatted lin arguments if services are present and contain a persistent service', () => {
-      expect(command.getLinks({ services: [ { foo: {} }, { bar: { persist: true } } ] })).to.deep.equal([ '--link', 'dl_foo_test:foo', '--link', 'bar:bar' ])
+      expect(command.getLinks({ services: [{ foo: {} }, { bar: { persist: true } }] })).to.deep.equal(['--link', 'dl_foo_test:foo', '--link', 'bar:bar'])
     })
   })
   describe('get', () => {
@@ -85,15 +85,15 @@ describe('command', () => {
     })
     it('returns array of arguments for a service config', () => {
       process.env.DL_TEST_EV = 'foo'
-      const actual = command.get({ from: 'mongo', env: [ 'DL_TEST_EV=${DL_TEST_EV}' ], expose: [ '8080:8080', '9090:9090' ] }, 'mongo') // eslint-disable-line no-template-curly-in-string
-      expect(actual).to.deep.equal([ 'run', '-d', '--rm', '--privileged', '-e', 'DL_TEST_EV=foo', '-p', '8080:8080', '-p', '9090:9090', '--name', 'dl_mongo_test', 'mongo' ])
+      const actual = command.get({ from: 'mongo', env: ['DL_TEST_EV=${DL_TEST_EV}'], expose: ['8080:8080', '9090:9090'] }, 'mongo') // eslint-disable-line no-template-curly-in-string
+      expect(actual).to.deep.equal(['run', '-d', '--rm', '--privileged', '-e', 'DL_TEST_EV=foo', '-p', '8080:8080', '-p', '9090:9090', '--name', 'dl_mongo_test', 'mongo'])
       delete process.env.DL_TEST_EV
     })
     it('returns object with array of arguments and command for a primary container config', () => {
       process.env.DL_TEST_EV = 'foo'
-      const actual = command.get({ from: 'mongo', env: [ 'DL_TEST_EV=${DL_TEST_EV}' ], expose: [ '8080:8080' ], run: [ 'foo' ], tasks: { foo: 'echo "foo"' } }, 'primary', '/tmp', true) // eslint-disable-line no-template-curly-in-string
+      const actual = command.get({ from: 'mongo', env: ['DL_TEST_EV=${DL_TEST_EV}'], expose: ['8080:8080'], run: ['foo'], tasks: { foo: 'echo "foo"' } }, 'primary', '/tmp', true) // eslint-disable-line no-template-curly-in-string
       expect(actual).to.deep.equal({
-        args: [ 'run', '--rm', '-it', '-v', '/tmp:/tmp', '-v', '/tmp:/tmp', '-w', '/tmp', '--privileged', '-e', 'DL_TEST_EV=foo', '-p', '8080:8080', '--name', 'dl_primary_test', 'mongo', 'sh', '/tmp/devlab.sh' ],
+        args: ['run', '--rm', '-it', '-v', '/tmp:/tmp', '-v', '/tmp:/tmp', '-w', '/tmp', '--privileged', '-e', 'DL_TEST_EV=foo', '-p', '8080:8080', '--name', 'dl_primary_test', 'mongo', 'sh', '/tmp/devlab.sh'],
         cmd: '#!/bin/sh\nset -e;\necho "foo"'
       })
       delete process.env.DL_TEST_EV

--- a/test/src/index.spec.js
+++ b/test/src/index.spec.js
@@ -46,19 +46,19 @@ describe('index', () => {
       return expect(instance.startServices(cfg)).to.be.fulfilled()
     })
     it('resolves after services are successfully started', () => {
-      const cfg = { services: [ 'foo', 'bar' ] }
+      const cfg = { services: ['foo', 'bar'] }
       servicesRunStub = sinon.stub(services, 'run', () => Promise.resolve())
       return expect(instance.startServices(cfg)).to.be.fulfilled()
     })
     it('rejects after services fail to start', () => {
-      const cfg = { services: [ 'foo' ] }
+      const cfg = { services: ['foo'] }
       servicesRunStub = sinon.stub(services, 'run', () => Promise.reject())
       return expect(instance.startServices(cfg)).to.be.rejected()
     })
   })
   describe('stopServices', () => {
     beforeEach(() => {
-      services.running = [ 'foo', 'bar' ]
+      services.running = ['foo', 'bar']
     })
     afterEach(() => {
       if (servicesStopStub) servicesStopStub.restore()
@@ -84,7 +84,7 @@ describe('index', () => {
     })
     it('starts command, succeeds, and resolves with stopServices', () => {
       procRunStub = sinon.stub(proc, 'run', () => Promise.resolve())
-      return instance.runCommand({ primary: [ 'foo' ] })
+      return instance.runCommand({ primary: ['foo'] })
         .then(() => {
           expect(outputLineStub).to.be.called()
           expect(outputSuccessStub).to.be.called()
@@ -92,7 +92,7 @@ describe('index', () => {
     })
     it('starts command, fails, and throws', () => {
       procRunStub = sinon.stub(proc, 'run', () => Promise.reject(1))
-      return expect(instance.runCommand({ primary: [ 'foo' ] })).to.be.rejectedWith('Command failed')
+      return expect(instance.runCommand({ primary: ['foo'] })).to.be.rejectedWith('Command failed')
     })
   })
   describe('getConfig', () => {
@@ -103,7 +103,7 @@ describe('index', () => {
       })
     })
     it('loads config and args and returns task run command objects', () => {
-      args.raw = { f: 'node:6', _: [ 'env' ], c: configPath }
+      args.raw = { f: 'node:6', _: ['env'], c: configPath }
       return instance.getConfig().then(cfg => {
         expect(cfg).to.deep.equal(fixtures.task)
       })
@@ -126,7 +126,7 @@ describe('index', () => {
       return expect(instance.start()).to.be.rejectedWith('Process failed')
     })
     it('throws and outputs error when config throws', () => {
-      args.raw = { 'not-a-flag': true, _: [ 'env' ], c: configPath }
+      args.raw = { 'not-a-flag': true, _: ['env'], c: configPath }
       return instance.start().then(() => new Error('Should have failed'))
         .catch(() => {
           expect(outputErrorStub).to.be.calledWith('Invalid argument \'not-a-flag\', please see documentation')
@@ -134,7 +134,7 @@ describe('index', () => {
     })
     it('throws when unable to start services', () => {
       sinon.stub(instance, 'startServices', () => Promise.reject())
-      args.raw = { _: [ 'env' ], c: configPath }
+      args.raw = { _: ['env'], c: configPath }
       return expect(instance.start()).to.be.rejected()
     })
     it('throws when unable to write exec file to tmp', () => {
@@ -142,7 +142,7 @@ describe('index', () => {
       sinon.stub(instance, 'startServices', () => Promise.resolve())
       sinon.stub(instance, 'runCommand', () => Promise.resolve())
       sinon.stub(fs, 'unlinkAsync', () => Promise.resolve())
-      args.raw = { 'f': 'notactuallyanimage', _: [ 'env' ], c: configPath }
+      args.raw = { 'f': 'notactuallyanimage', _: ['env'], c: configPath }
       return expect(instance.start()).to.be.rejected()
     })
     it('throws when unable to start primary container', () => {
@@ -150,7 +150,7 @@ describe('index', () => {
       sinon.stub(instance, 'startServices', () => Promise.resolve())
       sinon.stub(instance, 'runCommand', () => Promise.reject())
       sinon.stub(fs, 'unlinkAsync', () => Promise.resolve())
-      args.raw = { 'f': 'notactuallyanimage', _: [ 'env' ], c: configPath }
+      args.raw = { 'f': 'notactuallyanimage', _: ['env'], c: configPath }
       return expect(instance.start()).to.be.rejected()
     })
     it('resolves when config, services and primary container run successfully', () => {
@@ -158,7 +158,7 @@ describe('index', () => {
       sinon.stub(instance, 'startServices', () => Promise.resolve())
       sinon.stub(instance, 'runCommand', () => Promise.resolve())
       sinon.stub(fs, 'unlinkAsync', () => Promise.resolve())
-      args.raw = { _: [ 'env' ], c: configPath }
+      args.raw = { _: ['env'], c: configPath }
       return expect(instance.start()).to.be.fulfilled()
     })
   })

--- a/test/src/proc.spec.js
+++ b/test/src/proc.spec.js
@@ -4,13 +4,13 @@ const cp = require('child_process')
 describe('proc', () => {
   describe('run', () => {
     it('rejects after a process exits with non-0 code', () => {
-      return expect(proc.run([ 'foo' ])).to.be.rejected()
+      return expect(proc.run(['foo'])).to.be.rejected()
     })
     it('resolves when a process runs and exits with 0 code', () => {
-      return expect(proc.run([ 'ps' ])).to.be.fulfilled()
+      return expect(proc.run(['ps'])).to.be.fulfilled()
     })
     it('runs silently if `silent` flag is passed', () => {
-      return expect(proc.run([ 'ps' ], true)).to.be.fulfilled()
+      return expect(proc.run(['ps'], true)).to.be.fulfilled()
     })
   })
   describe('runDetached', () => {
@@ -21,7 +21,7 @@ describe('proc', () => {
     afterEach(() => cpSpawnStub.restore())
     it('runs a detached process', () => {
       proc.runDetached('echo "foo"')
-      expect(cpSpawnStub).to.be.calledWith('sh', [ '-c', 'echo "foo"' ])
+      expect(cpSpawnStub).to.be.calledWith('sh', ['-c', 'echo "foo"'])
     })
   })
 })

--- a/test/src/services.spec.js
+++ b/test/src/services.spec.js
@@ -18,7 +18,7 @@ describe('services', () => {
     it('returns an array of services and their command arrays', () => {
       const svc = services.get(config.load())
       expect(svc[0].name).to.equal('mongodb')
-      expect(svc[0].args).to.deep.equal([ 'run', '-d', '--rm', '--privileged', '-p', '27017:27017', '--name', 'dl_mongodb_test', 'mongo:3.0' ])
+      expect(svc[0].args).to.deep.equal(['run', '-d', '--rm', '--privileged', '-p', '27017:27017', '--name', 'dl_mongodb_test', 'mongo:3.0'])
     })
   })
   describe('run', () => {
@@ -35,12 +35,12 @@ describe('services', () => {
       })
       procRunStub = sinon.stub(proc, 'run', () => Promise.resolve())
       return services.run(fixture).then(() => {
-        expect(services.running).to.deep.equal([ { name: 'dl_mongodb_test', stopTimeSecs: 10 } ])
+        expect(services.running).to.deep.equal([{ name: 'dl_mongodb_test', stopTimeSecs: 10 }])
       })
     })
     it('rejects when a service fails to start', () => {
       procRunStub = sinon.stub(proc, 'run', () => Promise.reject())
-      return services.run([ { name: 'fart', args: [ 'foo' ] } ])
+      return services.run([{ name: 'fart', args: ['foo'] }])
         .then(() => {
           throw new Error('Should have failed')
         })
@@ -55,7 +55,7 @@ describe('services', () => {
       procRunStub = sinon.stub(proc, 'run', (svc) => Promise.resolve().then(() => {
         if (svc === 'dl_fail_test') {
           const testError = new Error()
-          testError.svcs = [ 'dl_fail_test' ]
+          testError.svcs = ['dl_fail_test']
           throw testError
         }
         return
@@ -72,26 +72,26 @@ describe('services', () => {
         })
     })
     it('resolves after calling proc.run with stop command for running services', () => {
-      services.running = [ { name: 'dl_foo_test', stopTimeSecs: 10 }, { name: 'dl_bar_test', stopTimeSecs: 10 } ]
+      services.running = [{ name: 'dl_foo_test', stopTimeSecs: 10 }, { name: 'dl_bar_test', stopTimeSecs: 10 }]
       return services.stop()
         .then(() => {
-          expect(procRunStub.getCalls()[0].args[0]).to.deep.equal([ 'stop', '-t', 10, 'dl_foo_test' ])
-          expect(procRunStub.getCalls()[1].args[0]).to.deep.equal([ 'stop', '-t', 10, 'dl_bar_test' ])
+          expect(procRunStub.getCalls()[0].args[0]).to.deep.equal(['stop', '-t', 10, 'dl_foo_test'])
+          expect(procRunStub.getCalls()[1].args[0]).to.deep.equal(['stop', '-t', 10, 'dl_bar_test'])
         })
     })
     it('resolves after calling proc with stop and rm only for non-persistent services', () => {
-      services.running = [ { name: 'dl_foo_test', stopTimeSecs: 10 }, { name: 'bar' } ]
+      services.running = [{ name: 'dl_foo_test', stopTimeSecs: 10 }, { name: 'bar' }]
       return services.stop()
         .then(() => {
-          expect(procRunStub.getCalls()[0].args[0]).to.deep.equal([ 'stop', '-t', 10, 'dl_foo_test' ])
+          expect(procRunStub.getCalls()[0].args[0]).to.deep.equal(['stop', '-t', 10, 'dl_foo_test'])
         })
     })
     it('rejects with error containing names of services that failed', () => {
-      services.running = [ 'dl_foo_test', 'dl_fail_test' ]
+      services.running = ['dl_foo_test', 'dl_fail_test']
       return services.stop()
         .catch((err) => {
-          expect(procRunStub.getCalls()[0].args[0]).to.deep.equal([ 'stop', 'dl_foo_test' ])
-          expect(err.svcs).to.deep.equal([ 'dl_fail_test' ])
+          expect(procRunStub.getCalls()[0].args[0]).to.deep.equal(['stop', 'dl_foo_test'])
+          expect(err.svcs).to.deep.equal(['dl_fail_test'])
         })
     })
   })
@@ -104,27 +104,27 @@ describe('services', () => {
       expect(services.filterEnabled(cfg)).to.deep.equal(cfg)
     })
     it('does nothing if single task config is not an object', () => {
-      const cfg = { run: [ 'test' ], tasks: { test: 'echo "not an obj"' } }
+      const cfg = { run: ['test'], tasks: { test: 'echo "not an obj"' } }
       expect(services.filterEnabled(cfg)).to.deep.equal(cfg)
     })
     it('does nothing if any task config is not an object', () => {
-      const cfg = { run: [ 'string', 'obj' ], tasks: { string: 'echo "not an obj"', obj: { disable: '*' } } }
+      const cfg = { run: ['string', 'obj'], tasks: { string: 'echo "not an obj"', obj: { disable: '*' } } }
       expect(services.filterEnabled(cfg)).to.deep.equal(cfg)
     })
     it('disables all services when \'*\' is supplied', () => {
       const cfg = {
         services: [{ disabledOne: { from: 'test' } }, { disabledTwo: { from: 'disable' } }],
         tasks: { test: { disable: '*', cmd: 'echo hello' } },
-        run: [ 'test' ]
+        run: ['test']
       }
       expect(services.filterEnabled(cfg).services).to.deep.equal([])
-      expect(services.disabled).to.deep.equal([ 'disabledOne', 'disabledTwo' ])
+      expect(services.disabled).to.deep.equal(['disabledOne', 'disabledTwo'])
     })
     it('returns config with filtered services array', () => {
       const cfg = {
         services: [{ keep: { from: 'test' } }, { disable: { from: 'disable' } }],
-        tasks: { test: { disable: [ 'disable' ], cmd: 'echo hello' } },
-        run: [ 'test' ]
+        tasks: { test: { disable: ['disable'], cmd: 'echo hello' } },
+        run: ['test']
       }
       expect(services.filterEnabled(cfg).services).to.deep.equal([{ keep: { from: 'test' } }])
       expect(services.disabled[0]).to.equal('disable')
@@ -132,8 +132,8 @@ describe('services', () => {
     it('disables services shared between chained tasks', () => {
       const cfg = {
         services: [{ shared: { from: 'test' } }, { onlyTest: { from: 'onlyTest' } }],
-        tasks: { test: { disable: '*', cmd: 'echo hello' }, lint: { disable: [ 'shared' ], cmd: 'lint' } },
-        run: [ 'test', 'lint' ]
+        tasks: { test: { disable: '*', cmd: 'echo hello' }, lint: { disable: ['shared'], cmd: 'lint' } },
+        run: ['test', 'lint']
       }
       expect(services.filterEnabled(cfg).services).to.deep.equal([{ onlyTest: { from: 'onlyTest' } }])
       expect(services.disabled[0]).to.equal('shared')

--- a/test/system/run.js
+++ b/test/system/run.js
@@ -18,10 +18,10 @@ const executable = path.resolve(__dirname, '../../index.js')
 
 // Runs proc
 const spawn = (args) => new Promise((resolve, reject) => {
-  const p = require('child_process').spawn('node', [ executable, ...args ], {
+  const p = require('child_process').spawn('node', [executable, ...args], {
     env: process.env,
     cwd: testProject,
-    stdio: [ 'inherit', process.stdout, process.stdout ]
+    stdio: ['inherit', process.stdout, process.stdout]
   })
   p.on('close', (code) => {
     code === 0 || code === 130 ? resolve() : reject(code)

--- a/test/system/tests.json
+++ b/test/system/tests.json
@@ -1,67 +1,67 @@
 {
   "help": {
     "description": "Displays the help message",
-    "args": [ "-h" ],
+    "args": ["-h"],
     "should": "pass"
   },
   "version": {
     "description": "Shows the current version",
-    "args": [ "-v" ],
+    "args": ["-v"],
     "should": "pass"
   },
   "install": {
     "description": "Installs dependencies for future tests",
-    "args": [ "install" ],
+    "args": ["install"],
     "should": "pass"
   },
   "basic": {
     "description": "Runs the 'env' task",
-    "args": [ "env" ],
+    "args": ["env"],
     "should": "pass"
   },
   "basic multiple": {
     "description": "Runs multiple tasks",
-    "args": [ "env", "test" ],
+    "args": ["env", "test"],
     "should": "pass"
   },
   "config": {
     "description": "Specifies the devlab.yml using command arg",
-    "args": [ "env", "-c", "devlab.yml" ],
+    "args": ["env", "-c", "devlab.yml"],
     "should": "pass"
   },
   "config fail": {
     "description": "Specifies an invalid config and fails",
-    "args": [ "env", "-c", "not-a-config.yml" ],
+    "args": ["env", "-c", "not-a-config.yml"],
     "should": "fail"
   },
   "from": {
     "description": "Runs the 'env' task with custom from",
-    "args": [ "env", "-f", "mhart/alpine-node:4" ],
+    "args": ["env", "-f", "mhart/alpine-node:4"],
     "should": "pass"
   },
   "exec": {
     "description": "Runs with custom execution task and passes",
-    "args": [ "-e", "echo 'foo'" ],
+    "args": ["-e", "echo 'foo'"],
     "should": "pass"
   },
   "exec fail": {
     "description": "Runs with custom execution task and fails",
-    "args": [ "-e", "not-a-command" ],
+    "args": ["-e", "not-a-command"],
     "should": "fail"
   },
   "invalid arg": {
     "description": "Fails when invalid argument is passed",
-    "args": [ "env", "-w" ],
+    "args": ["env", "-w"],
     "should": "fail"
   },
   "disabled service": {
     "description": "Fails because required service is disabled",
-    "args": [ "redis:disable" ],
+    "args": ["redis:disable"],
     "should": "fail"
   },
   "ignore disable": {
     "description": "Passes because service is not disabled for all tasks",
-    "args": [ "env", "redis:disable" ],
+    "args": ["env", "redis:disable"],
     "should": "pass"
   }
 }


### PR DESCRIPTION
1. Remove `eslint` (not used) and update `standard`
1. Normalize array bracket spacing.  The project used a mix of `[foo]` and `[ foo ]`.  I went with the most common, no spaces: `[foo]`.
1. Add [`snazzy`](https://github.com/feross/snazzy)

    **Before:**
    ![image](https://cloud.githubusercontent.com/assets/5067638/24591042/61150644-17ad-11e7-8f47-81ea38c3a098.png)

    **After:**
    ![image](https://cloud.githubusercontent.com/assets/5067638/24591045/7a90004c-17ad-11e7-9c67-68be76831855.png)