### PR TITLE
fix(devlab-no-rm): return DEVLAB_NO_RM env var support for CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,12 @@ The `stopTimeSecs` above would forcibly stop the container after 3 seconds using
 
 In addition to setting the `stopTimeSecs` per service, this property can be set in the root of the `devlab.yml` configuration and will be applied to any services that don't have an explicit `stopTimeSecs` property.
 
+## Service Removal
+
+In earlier versions of Docker, the `-d` (detached) and `--rm` (remove) flags conflict, however, Devlab uses these together which may cause issue on older systems.
+
+If running `docker run -d --rm <container>` causes this error the `--rm` flag can be circumvented by setting the `DEVLAB_NO_RM` environment variable to `true`.
+
 ## Development
 
 To run tests, fork & clone the repository then run `npm install && npm test`.

--- a/src/command.js
+++ b/src/command.js
@@ -103,7 +103,9 @@ const command = {
   get: (cfg, name, tmpdir, primary = false) => {
     if (!cfg.from) throw new Error('Missing \'from\' property in config or argument')
     const cwd = process.cwd()
-    let args = primary ? ['run', '--rm', '-it', '-v', `${cwd}:${cwd}`, '-v', `${tmpdir}:${tmpdir}`, '-w', cwd, '--privileged'] : ['run', '-d', '--rm', '--privileged']
+    /* istanbul ignore next */
+    const serviceArgs = process.env.DEVLAB_NO_RM ? ['run', '-d', '--privileged'] : ['run', '-d', '--rm', '--privileged']
+    let args = primary ? ['run', '--rm', '-it', '-v', `${cwd}:${cwd}`, '-v', `${tmpdir}:${tmpdir}`, '-w', cwd, '--privileged'] : serviceArgs
     args = args.concat(_.flatten([
       command.getArgs(cfg),
       command.getLinks(cfg),


### PR DESCRIPTION
This is a bit of a hack. Pushing out a patch so our CI builds don't fail because of old Docker version on Circle.