### PR TITLE
Feat: disable services via command line argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,18 @@ tasks:
   start: npm start
 ```
 
+For one-off cases, individual services can also be disabled via the command line:
+
+```
+lab lint -d mongo
+```
+
+or all services:
+
+```
+lab lint --disable-all
+```
+
 ## Container Management
 
 Devlab will automatically `stop` services after any run (success or fail). However, if this fails or some other fringe-case causes this process to stop responding the system can leave orphaned containers running.

--- a/src/args.js
+++ b/src/args.js
@@ -27,14 +27,22 @@ const args = {
     'f': { prop: 'from', help: 'Run with specified docker image' },
     'c': { prop: 'configPath', help: 'Run with custom config file path' },
     'd': { action: 'disable', help: 'Disable specified service' },
-    // TODO
-    // 'disable-all': { action: 'disableAll', help: 'Disable all configured services' },
+    'disable-all': { action: 'disableAll', help: 'Disable all configured services' },
     'tasks': { action: 'tasks', help: 'List all available tasks' },
     'cleanup': { action: 'cleanupDL', help: 'Stops and removes any non-persisted Devlab containers' },
     'cleanup-all': { action: 'cleanupAll', help: 'Stops and removes ALL docker containers' }
   },
+  /**
+   * Adds specified service names to disabled list
+   */
   disable: () => {
     services.disabled = Array.isArray(args.raw.d) ? _.unique(args.raw.d) : [ args.raw.d ]
+  },
+  /**
+   * Marks all services to be disabled
+   */
+  disableAll: () => {
+    services.disableAll = true
   },
   /**
    * List all available tasks

--- a/src/args.js
+++ b/src/args.js
@@ -4,6 +4,7 @@ const _ = require('halcyon')
 const min = require('minimist')
 const pkg = require('../package.json')
 const utils = require('./utils')
+const services = require('./services')
 
 /* istanbul ignore next */
 const processArgs = process.argv[0] === 'node' ? 1 : 2
@@ -25,9 +26,15 @@ const args = {
     'e': { prop: 'exec', help: 'Run a custom command instead of defined task' },
     'f': { prop: 'from', help: 'Run with specified docker image' },
     'c': { prop: 'configPath', help: 'Run with custom config file path' },
+    'd': { action: 'disable', help: 'Disable specified service' },
+    // TODO
+    // 'disable-all': { action: 'disableAll', help: 'Disable all configured services' },
     'tasks': { action: 'tasks', help: 'List all available tasks' },
     'cleanup': { action: 'cleanupDL', help: 'Stops and removes any non-persisted Devlab containers' },
     'cleanup-all': { action: 'cleanupAll', help: 'Stops and removes ALL docker containers' }
+  },
+  disable: () => {
+    services.disabled = Array.isArray(args.raw.d) ? _.unique(args.raw.d) : [ args.raw.d ]
   },
   /**
    * List all available tasks

--- a/src/services.js
+++ b/src/services.js
@@ -23,11 +23,17 @@ const services = {
     const tasks = _.values(_.pick(cfg.run, cfg.tasks))
     const objs = _.filter(_.isType('object'), tasks)
     // If any running task doesn't have object config and no services specified in command line, keep all services
-    if (objs.length !== tasks.length && !services.disabled.length) return cfg
-    const svcs = _.unique([
-      ...services.disabled,
-      ..._.chain(t => t.disable === '*' ? _.map(_.keys, cfg.services) : t.disable, objs)
-    ])
+    if (objs.length !== tasks.length && !services.disabled.length && !services.disableAll) return cfg
+    const allSvcs = _.map(_.keys, cfg.services)
+    let svcs
+    if (services.disableAll) {
+      svcs = _.flatten(allSvcs)
+    } else {
+      svcs = _.unique([
+        ...services.disabled,
+        ..._.chain(t => t.disable === '*' ? allSvcs : t.disable, objs)
+      ])
+    }
     // Track which services are disabled by running tasks
     const counts = _.pipe([
       _.groupBy(_.identity),

--- a/src/services.js
+++ b/src/services.js
@@ -22,16 +22,19 @@ const services = {
     if (!cfg.run.length) return cfg
     const tasks = _.values(_.pick(cfg.run, cfg.tasks))
     const objs = _.filter(_.isType('object'), tasks)
-    // If any running task doesn't have object config, keep all services
-    if (objs.length !== tasks.length) return cfg
-    const svcs = _.chain(t => t.disable === '*' ? _.map(_.keys, cfg.services) : t.disable, objs)
+    // If any running task doesn't have object config and no services specified in command line, keep all services
+    if (objs.length !== tasks.length && !services.disabled.length) return cfg
+    const svcs = _.unique([
+      ...services.disabled,
+      ..._.chain(t => t.disable === '*' ? _.map(_.keys, cfg.services) : t.disable, objs)
+    ])
     // Track which services are disabled by running tasks
     const counts = _.pipe([
       _.groupBy(_.identity),
       _.map(_.length)
     ])(svcs)
     // Add service to list if disabled by all running tasks
-    services.disabled = _.keys(_.filter(_.equals(objs.length), counts))
+    services.disabled = _.keys(_.filter(_.equals(tasks.length), counts))
     /* istanbul ignore if: lots of work, testing doesn't prove anything... */
     if (!services.disabled.length) return cfg
     // Keep service if name is not in disabled list

--- a/test/project/devlab.yml
+++ b/test/project/devlab.yml
@@ -23,6 +23,7 @@ tasks:
   test: npm run test
   lint: npm run lint
   shell: /bin/sh
+  connect: node scripts/connect
   redis:disable:
     disable:
       - redis

--- a/test/src/args.spec.js
+++ b/test/src/args.spec.js
@@ -13,11 +13,10 @@ describe('args', () => {
   beforeEach(() => {
     sandbox.spy(console, 'log')
     sandbox.stub(process, 'exit')
+    services.disabled = []
+    services.disableAll = false
   })
   describe('disable', () => {
-    afterEach(() => {
-      services.disabled = []
-    })
     it('assigns unique values to services.disabled array', () => {
       args.raw = { d: ['foo', 'bar', 'foo'] }
       args.disable()
@@ -27,6 +26,13 @@ describe('args', () => {
       args.raw = { d: 'foo' }
       args.disable()
       expect(services.disabled).to.deep.equal([ 'foo' ])
+    })
+  })
+  describe('disableAll', () => {
+    it('sets services.disableAll to true', () => {
+      args.raw = { 'disable-all': true }
+      args.disableAll()
+      expect(services.disableAll).to.be.true()
     })
   })
   describe('tasks', () => {

--- a/test/src/args.spec.js
+++ b/test/src/args.spec.js
@@ -3,6 +3,7 @@ const fs = require('fs')
 const pkg = require('package.json')
 const args = require('src/args')
 const utils = require('src/utils')
+const services = require('src/services')
 const sandbox = require('test/sandbox')
 
 const fixtures = {
@@ -12,6 +13,21 @@ describe('args', () => {
   beforeEach(() => {
     sandbox.spy(console, 'log')
     sandbox.stub(process, 'exit')
+  })
+  describe('disable', () => {
+    afterEach(() => {
+      services.disabled = []
+    })
+    it('assigns unique values to services.disabled array', () => {
+      args.raw = { d: ['foo', 'bar', 'foo'] }
+      args.disable()
+      expect(services.disabled).to.deep.equal([ 'foo', 'bar' ])
+    })
+    it('pushes single value to services.disabled array', () => {
+      args.raw = { d: 'foo' }
+      args.disable()
+      expect(services.disabled).to.deep.equal([ 'foo' ])
+    })
   })
   describe('tasks', () => {
     const confPath = `${process.cwd()}/devlab.yml`

--- a/test/src/services.spec.js
+++ b/test/src/services.spec.js
@@ -132,6 +132,7 @@ describe('services', () => {
   describe('filterEnabled', () => {
     afterEach(() => {
       services.disabled = []
+      services.disableAll = false
     })
     it('does nothing if no task is supplied', () => {
       const cfg = { run: [] }
@@ -151,6 +152,16 @@ describe('services', () => {
         tasks: { test: { disable: '*', cmd: 'echo hello' } },
         run: ['test']
       }
+      expect(services.filterEnabled(cfg).services).to.deep.equal([])
+      expect(services.disabled).to.deep.equal(['disabledOne', 'disabledTwo'])
+    })
+    it('disables all services when disableAll is true', () => {
+      const cfg = {
+        services: [{ disabledOne: { from: 'test' } }, { disabledTwo: { from: 'disable' } }],
+        tasks: { test: 'echo hello' },
+        run: ['test']
+      }
+      services.disableAll = true
       expect(services.filterEnabled(cfg).services).to.deep.equal([])
       expect(services.disabled).to.deep.equal(['disabledOne', 'disabledTwo'])
     })

--- a/test/system/tests.json
+++ b/test/system/tests.json
@@ -63,5 +63,10 @@
     "description": "Passes because service is not disabled for all tasks",
     "args": ["env", "redis:disable"],
     "should": "pass"
+  },
+  "cli disable": {
+    "description": "Fails because required service is disabled via command line",
+    "args": ["connect", "-d", "redis"],
+    "should": "fail"
   }
 }


### PR DESCRIPTION
This PR introduces support for disabling services via the command line, either individually with`-d <service>`, or collectively with `--disable-all`.

Disabling services for chained tasks still functions the same as it currently does—ie., if a task in the chain requires one of the disabled services, it will start as normal.